### PR TITLE
feat: AI SQL Assistant with multi-provider support

### DIFF
--- a/apps/web-client/src/App.tsx
+++ b/apps/web-client/src/App.tsx
@@ -64,6 +64,8 @@ function AppContent() {
 		setShowToastHistory,
 		showExamples,
 		setShowExamples,
+		showAIChat,
+		setShowAIChat,
 		showExplorer,
 		setShowExplorer,
 		toggleExplorer,
@@ -521,15 +523,27 @@ function AppContent() {
 
 	const showExamplesButton = useSettingsStore((s) => s.showExamplesButton);
 
-	// Toggle examples with mutual exclusivity (closes toast history when opening)
+	// Toggle examples with mutual exclusivity (closes toast history and AI chat when opening)
 	const toggleExamples = useCallback(() => {
 		setShowExamples((prev) => {
 			if (!prev) {
 				setShowToastHistory(false);
+				setShowAIChat(false);
 			}
 			return !prev;
 		});
-	}, [setShowExamples, setShowToastHistory]);
+	}, [setShowExamples, setShowToastHistory, setShowAIChat]);
+
+	// Toggle AI chat with mutual exclusivity
+	const toggleAIChat = useCallback(() => {
+		setShowAIChat((prev) => {
+			if (!prev) {
+				setShowToastHistory(false);
+				setShowExamples(false);
+			}
+			return !prev;
+		});
+	}, [setShowAIChat, setShowToastHistory, setShowExamples]);
 
 	useKeyboardShortcuts({
 		onNewTab: handleTabAdd,
@@ -540,6 +554,7 @@ function AppContent() {
 		onNextTab: handleNextTab,
 		onPrevTab: handlePrevTab,
 		onRotateTheme: handleRotateTheme,
+		onToggleAIChat: toggleAIChat,
 		canCloseTab: tabs.length > 1,
 	});
 
@@ -568,6 +583,8 @@ function AppContent() {
 				showSettings={showSettings}
 				onToggleSettings={() => setShowSettings(!showSettings)}
 				onOpenServerSettings={() => openSettings("server")}
+				showAIChat={showAIChat}
+				onToggleAIChat={toggleAIChat}
 			/>
 
 			<TabBar
@@ -765,6 +782,12 @@ function AppContent() {
 				onConflictReload={handleConflictReload}
 				onConflictSaveAs={handleConflictSaveAs}
 				onCancelConflict={() => setFileConflict(null)}
+				showAIChat={showAIChat}
+				onCloseAIChat={() => setShowAIChat(false)}
+				onInsertSQL={(sql) => {
+					editorRef.current?.insertAtCursor(sql);
+				}}
+				editorContent={editorRef.current?.getValue() || ""}
 			/>
 		</div>
 	);

--- a/apps/web-client/src/App.tsx
+++ b/apps/web-client/src/App.tsx
@@ -787,7 +787,7 @@ function AppContent() {
 				onInsertSQL={(sql) => {
 					editorRef.current?.insertAtCursor(sql);
 				}}
-				editorContent={editorRef.current?.getValue() || ""}
+				getEditorContent={() => editorRef.current?.getValue() || ""}
 			/>
 		</div>
 	);

--- a/apps/web-client/src/components/AIChatMessage.tsx
+++ b/apps/web-client/src/components/AIChatMessage.tsx
@@ -153,6 +153,27 @@ function TextBlock({ text }: { text: string }) {
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
 
+		// Headings
+		const headingMatch = line.match(/^(#{1,3})\s+(.+)$/);
+		if (headingMatch) {
+			const level = headingMatch[1].length;
+			const sizes = { 1: "16px", 2: "14px", 3: "13px" } as Record<number, string>;
+			elements.push(
+				<div
+					key={i}
+					style={{
+						fontSize: sizes[level] || "13px",
+						fontWeight: 600,
+						marginTop: i > 0 ? "8px" : 0,
+						marginBottom: "4px",
+					}}
+				>
+					{formatInline(headingMatch[2])}
+				</div>,
+			);
+			continue;
+		}
+
 		// List items
 		if (line.match(/^\s*[-*]\s/)) {
 			elements.push(

--- a/apps/web-client/src/components/AIChatMessage.tsx
+++ b/apps/web-client/src/components/AIChatMessage.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import type { ChatMessage } from "../services/ai";
-import { CopyIcon, CheckIcon } from "./Icons";
+import { CheckIcon, CopyIcon } from "./Icons";
 
 interface AIChatMessageProps {
 	message: ChatMessage;
@@ -157,7 +157,10 @@ function TextBlock({ text }: { text: string }) {
 		const headingMatch = line.match(/^(#{1,3})\s+(.+)$/);
 		if (headingMatch) {
 			const level = headingMatch[1].length;
-			const sizes = { 1: "16px", 2: "14px", 3: "13px" } as Record<number, string>;
+			const sizes = { 1: "16px", 2: "14px", 3: "13px" } as Record<
+				number,
+				string
+			>;
 			elements.push(
 				<div
 					key={i}
@@ -178,11 +181,7 @@ function TextBlock({ text }: { text: string }) {
 		if (line.match(/^\s*[-*]\s/)) {
 			elements.push(
 				<div key={i} style={{ paddingLeft: "16px", position: "relative" }}>
-					<span
-						style={{ position: "absolute", left: "4px" }}
-					>
-						{"\u2022"}
-					</span>
+					<span style={{ position: "absolute", left: "4px" }}>{"\u2022"}</span>
 					{formatInline(line.replace(/^\s*[-*]\s/, ""))}
 				</div>,
 			);
@@ -217,9 +216,7 @@ function formatInline(text: string): React.ReactNode {
 		}
 		const token = match[0];
 		if (token.startsWith("**")) {
-			parts.push(
-				<strong key={match.index}>{token.slice(2, -2)}</strong>,
-			);
+			parts.push(<strong key={match.index}>{token.slice(2, -2)}</strong>);
 		} else if (token.startsWith("`")) {
 			parts.push(
 				<code
@@ -243,7 +240,7 @@ function formatInline(text: string): React.ReactNode {
 		parts.push(text.slice(lastIndex));
 	}
 
-	return parts.length === 1 ? parts[0] : <>{parts}</>;
+	return parts.length === 1 ? parts[0] : parts;
 }
 
 export function AIChatMessage({ message, onInsertSQL }: AIChatMessageProps) {

--- a/apps/web-client/src/components/AIChatMessage.tsx
+++ b/apps/web-client/src/components/AIChatMessage.tsx
@@ -1,0 +1,288 @@
+/**
+ * AIChatMessage Component
+ * Renders individual chat messages with SQL block extraction and action buttons.
+ */
+
+import React from "react";
+import type { ChatMessage } from "../services/ai";
+import { CopyIcon, CheckIcon } from "./Icons";
+
+interface AIChatMessageProps {
+	message: ChatMessage;
+	onInsertSQL?: (sql: string) => void;
+}
+
+/** Simple markdown-lite renderer: bold, inline code, lists, and SQL blocks */
+function renderContent(
+	content: string,
+	onInsertSQL?: (sql: string) => void,
+): React.ReactNode[] {
+	const nodes: React.ReactNode[] = [];
+	// Split on ```sql blocks
+	const parts = content.split(/(```sql\s*\n[\s\S]*?```)/gi);
+
+	for (let i = 0; i < parts.length; i++) {
+		const part = parts[i];
+		if (!part) continue;
+
+		const sqlMatch = part.match(/^```sql\s*\n([\s\S]*?)```$/i);
+		if (sqlMatch) {
+			const sql = sqlMatch[1].trim();
+			nodes.push(<SQLCodeBlock key={i} sql={sql} onInsert={onInsertSQL} />);
+		} else {
+			// Render as markdown-lite text
+			nodes.push(<TextBlock key={i} text={part} />);
+		}
+	}
+
+	return nodes;
+}
+
+function SQLCodeBlock({
+	sql,
+	onInsert,
+}: {
+	sql: string;
+	onInsert?: (sql: string) => void;
+}) {
+	const [copied, setCopied] = React.useState(false);
+
+	const handleCopy = async () => {
+		await navigator.clipboard.writeText(sql);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<div
+			style={{
+				margin: "8px 0",
+				borderRadius: "6px",
+				overflow: "hidden",
+				border: "1px solid var(--border-light)",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					padding: "4px 8px",
+					background: "var(--bg-quaternary)",
+					fontSize: "11px",
+					color: "var(--text-muted)",
+				}}
+			>
+				<span>SQL</span>
+				<div style={{ display: "flex", gap: "4px" }}>
+					{onInsert && (
+						<button
+							onClick={() => onInsert(sql)}
+							style={{
+								background: "var(--accent)",
+								color: "white",
+								border: "none",
+								borderRadius: "4px",
+								padding: "2px 8px",
+								fontSize: "11px",
+								cursor: "pointer",
+								transition: "opacity 0.2s",
+							}}
+							onMouseEnter={(e) => {
+								e.currentTarget.style.opacity = "0.8";
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.opacity = "1";
+							}}
+						>
+							Insert
+						</button>
+					)}
+					<button
+						onClick={handleCopy}
+						style={{
+							background: "transparent",
+							border: "1px solid var(--border-light)",
+							borderRadius: "4px",
+							padding: "2px 6px",
+							cursor: "pointer",
+							color: "var(--text-muted)",
+							display: "flex",
+							alignItems: "center",
+							gap: "3px",
+							fontSize: "11px",
+						}}
+					>
+						{copied ? (
+							<>
+								<CheckIcon size={10} /> Copied
+							</>
+						) : (
+							<>
+								<CopyIcon size={10} /> Copy
+							</>
+						)}
+					</button>
+				</div>
+			</div>
+			<pre
+				style={{
+					margin: 0,
+					padding: "10px 12px",
+					background: "var(--bg-tertiary)",
+					fontSize: "12px",
+					lineHeight: "1.5",
+					overflowX: "auto",
+					fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+					color: "var(--text-primary)",
+					whiteSpace: "pre-wrap",
+					wordBreak: "break-word",
+				}}
+			>
+				{sql}
+			</pre>
+		</div>
+	);
+}
+
+function TextBlock({ text }: { text: string }) {
+	// Process inline formatting
+	const lines = text.split("\n");
+	const elements: React.ReactNode[] = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+
+		// List items
+		if (line.match(/^\s*[-*]\s/)) {
+			elements.push(
+				<div key={i} style={{ paddingLeft: "16px", position: "relative" }}>
+					<span
+						style={{ position: "absolute", left: "4px" }}
+					>
+						{"\u2022"}
+					</span>
+					{formatInline(line.replace(/^\s*[-*]\s/, ""))}
+				</div>,
+			);
+		} else if (line.match(/^\s*\d+\.\s/)) {
+			const num = line.match(/^\s*(\d+)\.\s/)?.[1];
+			elements.push(
+				<div key={i} style={{ paddingLeft: "16px", position: "relative" }}>
+					<span style={{ position: "absolute", left: "0px" }}>{num}.</span>
+					{formatInline(line.replace(/^\s*\d+\.\s/, ""))}
+				</div>,
+			);
+		} else if (line.trim() === "") {
+			elements.push(<div key={i} style={{ height: "8px" }} />);
+		} else {
+			elements.push(<div key={i}>{formatInline(line)}</div>);
+		}
+	}
+
+	return <>{elements}</>;
+}
+
+function formatInline(text: string): React.ReactNode {
+	// Process **bold** and `inline code`
+	const parts: React.ReactNode[] = [];
+	const regex = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(text)) !== null) {
+		if (match.index > lastIndex) {
+			parts.push(text.slice(lastIndex, match.index));
+		}
+		const token = match[0];
+		if (token.startsWith("**")) {
+			parts.push(
+				<strong key={match.index}>{token.slice(2, -2)}</strong>,
+			);
+		} else if (token.startsWith("`")) {
+			parts.push(
+				<code
+					key={match.index}
+					style={{
+						background: "var(--bg-quaternary)",
+						padding: "1px 4px",
+						borderRadius: "3px",
+						fontSize: "0.9em",
+						fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+					}}
+				>
+					{token.slice(1, -1)}
+				</code>,
+			);
+		}
+		lastIndex = match.index + token.length;
+	}
+
+	if (lastIndex < text.length) {
+		parts.push(text.slice(lastIndex));
+	}
+
+	return parts.length === 1 ? parts[0] : <>{parts}</>;
+}
+
+export function AIChatMessage({ message, onInsertSQL }: AIChatMessageProps) {
+	const isUser = message.role === "user";
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				alignItems: isUser ? "flex-end" : "flex-start",
+				marginBottom: "12px",
+			}}
+		>
+			<div
+				style={{
+					maxWidth: "90%",
+					padding: "10px 14px",
+					borderRadius: isUser ? "14px 14px 4px 14px" : "14px 14px 14px 4px",
+					background: isUser ? "var(--accent)" : "var(--bg-secondary)",
+					color: isUser ? "white" : "var(--text-primary)",
+					fontSize: "13px",
+					lineHeight: "1.6",
+					wordBreak: "break-word",
+				}}
+			>
+				{isUser ? (
+					message.content
+				) : (
+					<>
+						{renderContent(message.content, onInsertSQL)}
+						{message.isStreaming && (
+							<span
+								style={{
+									display: "inline-block",
+									width: "6px",
+									height: "14px",
+									background: "var(--accent)",
+									marginLeft: "2px",
+									animation: "blink 1s step-end infinite",
+									verticalAlign: "text-bottom",
+								}}
+							/>
+						)}
+					</>
+				)}
+			</div>
+			<div
+				style={{
+					fontSize: "10px",
+					color: "var(--text-muted)",
+					marginTop: "4px",
+					padding: "0 4px",
+				}}
+			>
+				{new Date(message.timestamp).toLocaleTimeString([], {
+					hour: "2-digit",
+					minute: "2-digit",
+				})}
+			</div>
+		</div>
+	);
+}

--- a/apps/web-client/src/components/AIChatPanel.tsx
+++ b/apps/web-client/src/components/AIChatPanel.tsx
@@ -50,7 +50,9 @@ export function AIChatPanel({
 	useEffect(() => {
 		let cancelled = false;
 		(async () => {
-			const key = await aiCredentialStore.load(getCredentialKey(activeProvider));
+			const key = await aiCredentialStore.load(
+				getCredentialKey(activeProvider),
+			);
 			if (!cancelled) setHasApiKey(!!key);
 		})();
 		return () => {
@@ -61,7 +63,10 @@ export function AIChatPanel({
 	// Close on ESC only if focus is inside the panel
 	useEffect(() => {
 		const handleEsc = (e: KeyboardEvent) => {
-			if (e.key === "Escape" && panelRef.current?.contains(document.activeElement)) {
+			if (
+				e.key === "Escape" &&
+				panelRef.current?.contains(document.activeElement)
+			) {
 				onClose();
 			}
 		};
@@ -229,15 +234,13 @@ export function AIChatPanel({
 				) : messages.length === 0 ? (
 					<EmptyState />
 				) : (
-					<>
-						{messages.map((msg) => (
-							<AIChatMessage
-								key={msg.id}
-								message={msg}
-								onInsertSQL={onInsertSQL}
-							/>
-						))}
-					</>
+					messages.map((msg) => (
+						<AIChatMessage
+							key={msg.id}
+							message={msg}
+							onInsertSQL={onInsertSQL}
+						/>
+					))
 				)}
 				{error && (
 					<div
@@ -349,8 +352,7 @@ export function AIChatPanel({
 						onInput={(e) => {
 							const target = e.currentTarget;
 							target.style.height = "auto";
-							target.style.height =
-								Math.min(target.scrollHeight, 120) + "px";
+							target.style.height = Math.min(target.scrollHeight, 120) + "px";
 						}}
 						onFocus={(e) => {
 							e.currentTarget.style.borderColor = "var(--accent)";
@@ -443,11 +445,26 @@ function WelcomeCard({
 	activeProvider: AIProviderType;
 	onSelectProvider: (p: AIProviderType) => void;
 }) {
-	const providers: { type: AIProviderType; name: string; desc: string; free: boolean }[] = [
-		{ type: "gemini", name: "Google Gemini", desc: "Free - 15 req/min", free: true },
+	const providers: {
+		type: AIProviderType;
+		name: string;
+		desc: string;
+		free: boolean;
+	}[] = [
+		{
+			type: "gemini",
+			name: "Google Gemini",
+			desc: "Free - 15 req/min",
+			free: true,
+		},
 		{ type: "groq", name: "Groq", desc: "Free - 30 req/min", free: true },
 		{ type: "openai", name: "OpenAI", desc: "Paid - GPT-4o", free: false },
-		{ type: "anthropic", name: "Anthropic", desc: "Paid - Claude", free: false },
+		{
+			type: "anthropic",
+			name: "Anthropic",
+			desc: "Paid - Claude",
+			free: false,
+		},
 	];
 
 	const apiKeyUrls: Record<AIProviderType, string> = {
@@ -464,10 +481,7 @@ function WelcomeCard({
 				padding: "32px 16px",
 			}}
 		>
-			<SparklesIcon
-				size={40}
-				style={{ marginBottom: "16px", opacity: 0.4 }}
-			/>
+			<SparklesIcon size={40} style={{ marginBottom: "16px", opacity: 0.4 }} />
 			<h4
 				style={{
 					margin: "0 0 8px",
@@ -573,10 +587,7 @@ function EmptyState() {
 				color: "var(--text-muted)",
 			}}
 		>
-			<SparklesIcon
-				size={48}
-				style={{ marginBottom: "16px", opacity: 0.2 }}
-			/>
+			<SparklesIcon size={48} style={{ marginBottom: "16px", opacity: 0.2 }} />
 			<div style={{ fontSize: "14px", marginBottom: "6px" }}>
 				Ask anything about SQL
 			</div>

--- a/apps/web-client/src/components/AIChatPanel.tsx
+++ b/apps/web-client/src/components/AIChatPanel.tsx
@@ -5,9 +5,9 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { CredentialStore } from "@ide/storage";
 import {
 	type AIProviderType,
+	aiCredentialStore,
 	getAllProviderTypes,
 	getCredentialKey,
 	getProvider,
@@ -19,15 +19,13 @@ import { SendIcon, SparklesIcon, StopIcon, TrashIcon, XIcon } from "./Icons";
 interface AIChatPanelProps {
 	onClose: () => void;
 	onInsertSQL?: (sql: string) => void;
-	editorContent?: string;
+	getEditorContent?: () => string;
 }
-
-const credentialStore = new CredentialStore();
 
 export function AIChatPanel({
 	onClose,
 	onInsertSQL,
-	editorContent,
+	getEditorContent,
 }: AIChatPanelProps) {
 	const panelRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -40,6 +38,7 @@ export function AIChatPanel({
 		isStreaming,
 		error,
 		activeProvider,
+		selectedModels,
 		sendMessage,
 		stopStreaming,
 		clearMessages,
@@ -51,7 +50,7 @@ export function AIChatPanel({
 	useEffect(() => {
 		let cancelled = false;
 		(async () => {
-			const key = await credentialStore.load(getCredentialKey(activeProvider));
+			const key = await aiCredentialStore.load(getCredentialKey(activeProvider));
 			if (!cancelled) setHasApiKey(!!key);
 		})();
 		return () => {
@@ -59,10 +58,12 @@ export function AIChatPanel({
 		};
 	}, [activeProvider]);
 
-	// Close on ESC
+	// Close on ESC only if focus is inside the panel
 	useEffect(() => {
 		const handleEsc = (e: KeyboardEvent) => {
-			if (e.key === "Escape") onClose();
+			if (e.key === "Escape" && panelRef.current?.contains(document.activeElement)) {
+				onClose();
+			}
 		};
 		document.addEventListener("keydown", handleEsc);
 		return () => document.removeEventListener("keydown", handleEsc);
@@ -77,8 +78,8 @@ export function AIChatPanel({
 		const trimmed = input.trim();
 		if (!trimmed || isStreaming) return;
 		setInput("");
-		sendMessage(trimmed, editorContent);
-	}, [input, isStreaming, sendMessage, editorContent]);
+		sendMessage(trimmed, getEditorContent?.());
+	}, [input, isStreaming, sendMessage, getEditorContent]);
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (e.key === "Enter" && !e.shiftKey) {
@@ -89,7 +90,7 @@ export function AIChatPanel({
 
 	const handleQuickAction = (prompt: string) => {
 		if (isStreaming) return;
-		sendMessage(prompt, editorContent);
+		sendMessage(prompt, getEditorContent?.());
 	};
 
 	const provider = getProvider(activeProvider);
@@ -165,6 +166,7 @@ export function AIChatPanel({
 						<button
 							onClick={clearMessages}
 							title="Clear chat"
+							aria-label="Clear chat history"
 							style={{
 								background: "transparent",
 								border: "none",
@@ -187,6 +189,8 @@ export function AIChatPanel({
 					)}
 					<button
 						onClick={onClose}
+						title="Close AI assistant"
+						aria-label="Close AI assistant panel"
 						style={{
 							background: "transparent",
 							border: "none",
@@ -271,7 +275,7 @@ export function AIChatPanel({
 						<button
 							key={action.label}
 							onClick={() => handleQuickAction(action.prompt)}
-							disabled={isStreaming || !editorContent?.trim()}
+							disabled={isStreaming}
 							style={{
 								background: "var(--bg-tertiary)",
 								border: "1px solid var(--border-light)",
@@ -279,15 +283,12 @@ export function AIChatPanel({
 								padding: "4px 12px",
 								fontSize: "12px",
 								color: "var(--text-secondary)",
-								cursor:
-									isStreaming || !editorContent?.trim()
-										? "not-allowed"
-										: "pointer",
-								opacity: isStreaming || !editorContent?.trim() ? 0.5 : 1,
+								cursor: isStreaming ? "not-allowed" : "pointer",
+								opacity: isStreaming ? 0.5 : 1,
 								transition: "all 0.2s",
 							}}
 							onMouseEnter={(e) => {
-								if (!isStreaming && editorContent?.trim()) {
+								if (!isStreaming) {
 									e.currentTarget.style.background = "var(--bg-quaternary)";
 									e.currentTarget.style.color = "var(--text-primary)";
 								}
@@ -362,6 +363,7 @@ export function AIChatPanel({
 						<button
 							onClick={stopStreaming}
 							title="Stop generating"
+							aria-label="Stop generating response"
 							style={{
 								background: "#ef4444",
 								color: "white",
@@ -383,6 +385,7 @@ export function AIChatPanel({
 							onClick={handleSend}
 							disabled={!input.trim() || hasApiKey === false}
 							title="Send message"
+							aria-label="Send message"
 							style={{
 								background:
 									input.trim() && hasApiKey !== false
@@ -419,7 +422,7 @@ export function AIChatPanel({
 						textAlign: "right",
 					}}
 				>
-					{provider.displayName} - {useAIChatStore.getState().selectedModels[activeProvider]}
+					{provider.displayName} - {selectedModels[activeProvider]}
 				</div>
 			</div>
 

--- a/apps/web-client/src/components/AIChatPanel.tsx
+++ b/apps/web-client/src/components/AIChatPanel.tsx
@@ -1,0 +1,585 @@
+/**
+ * AIChatPanel Component
+ * Right-side drawer for the AI SQL Assistant.
+ * Follows ToastHistory.tsx panel pattern.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { CredentialStore } from "@ide/storage";
+import {
+	type AIProviderType,
+	getAllProviderTypes,
+	getCredentialKey,
+	getProvider,
+} from "../services/ai";
+import { useAIChatStore } from "../stores/aiChatStore";
+import { AIChatMessage } from "./AIChatMessage";
+import { SendIcon, SparklesIcon, StopIcon, TrashIcon, XIcon } from "./Icons";
+
+interface AIChatPanelProps {
+	onClose: () => void;
+	onInsertSQL?: (sql: string) => void;
+	editorContent?: string;
+}
+
+const credentialStore = new CredentialStore();
+
+export function AIChatPanel({
+	onClose,
+	onInsertSQL,
+	editorContent,
+}: AIChatPanelProps) {
+	const panelRef = useRef<HTMLDivElement>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const [input, setInput] = useState("");
+	const [hasApiKey, setHasApiKey] = useState<boolean | null>(null);
+
+	const {
+		messages,
+		isStreaming,
+		error,
+		activeProvider,
+		sendMessage,
+		stopStreaming,
+		clearMessages,
+		setActiveProvider,
+		setError,
+	} = useAIChatStore();
+
+	// Check if API key is configured for active provider
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			const key = await credentialStore.load(getCredentialKey(activeProvider));
+			if (!cancelled) setHasApiKey(!!key);
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [activeProvider]);
+
+	// Close on ESC
+	useEffect(() => {
+		const handleEsc = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		document.addEventListener("keydown", handleEsc);
+		return () => document.removeEventListener("keydown", handleEsc);
+	}, [onClose]);
+
+	// Auto-scroll to bottom on new messages
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
+
+	const handleSend = useCallback(() => {
+		const trimmed = input.trim();
+		if (!trimmed || isStreaming) return;
+		setInput("");
+		sendMessage(trimmed, editorContent);
+	}, [input, isStreaming, sendMessage, editorContent]);
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSend();
+		}
+	};
+
+	const handleQuickAction = (prompt: string) => {
+		if (isStreaming) return;
+		sendMessage(prompt, editorContent);
+	};
+
+	const provider = getProvider(activeProvider);
+
+	return (
+		<div
+			ref={panelRef}
+			style={{
+				position: "fixed",
+				top: 0,
+				right: 0,
+				bottom: 0,
+				width: "450px",
+				background: "var(--bg-primary)",
+				borderLeft: "1px solid var(--border-light)",
+				boxShadow: "-4px 0 12px rgba(0, 0, 0, 0.15)",
+				zIndex: 10000,
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			{/* Header */}
+			<div
+				style={{
+					padding: "12px 16px",
+					borderBottom: "1px solid var(--border-light)",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					background: "var(--bg-secondary)",
+				}}
+			>
+				<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+					<SparklesIcon size={18} />
+					<h3
+						style={{
+							margin: 0,
+							fontSize: "15px",
+							fontWeight: 600,
+						}}
+					>
+						SQL Assistant
+					</h3>
+				</div>
+				<div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+					{/* Provider selector */}
+					<select
+						value={activeProvider}
+						onChange={(e) => {
+							setActiveProvider(e.target.value as AIProviderType);
+							setError(null);
+						}}
+						style={{
+							background: "var(--bg-tertiary)",
+							color: "var(--text-primary)",
+							border: "1px solid var(--border-light)",
+							borderRadius: "4px",
+							padding: "4px 6px",
+							fontSize: "12px",
+							cursor: "pointer",
+						}}
+					>
+						{getAllProviderTypes().map((t) => {
+							const p = getProvider(t);
+							return (
+								<option key={t} value={t}>
+									{p.displayName}
+								</option>
+							);
+						})}
+					</select>
+					{messages.length > 0 && (
+						<button
+							onClick={clearMessages}
+							title="Clear chat"
+							style={{
+								background: "transparent",
+								border: "none",
+								color: "var(--text-muted)",
+								cursor: "pointer",
+								padding: "4px",
+								borderRadius: "4px",
+								display: "flex",
+								alignItems: "center",
+							}}
+							onMouseEnter={(e) => {
+								e.currentTarget.style.background = "var(--bg-tertiary)";
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.background = "transparent";
+							}}
+						>
+							<TrashIcon size={14} />
+						</button>
+					)}
+					<button
+						onClick={onClose}
+						style={{
+							background: "transparent",
+							border: "none",
+							color: "var(--text-muted)",
+							cursor: "pointer",
+							padding: "4px",
+							borderRadius: "4px",
+							display: "flex",
+							alignItems: "center",
+						}}
+						onMouseEnter={(e) => {
+							e.currentTarget.style.background = "var(--bg-tertiary)";
+						}}
+						onMouseLeave={(e) => {
+							e.currentTarget.style.background = "transparent";
+						}}
+					>
+						<XIcon size={16} />
+					</button>
+				</div>
+			</div>
+
+			{/* Messages area */}
+			<div
+				style={{
+					flex: 1,
+					overflowY: "auto",
+					padding: "12px 16px",
+				}}
+			>
+				{hasApiKey === false ? (
+					<WelcomeCard
+						activeProvider={activeProvider}
+						onSelectProvider={(p) => setActiveProvider(p)}
+					/>
+				) : messages.length === 0 ? (
+					<EmptyState />
+				) : (
+					<>
+						{messages.map((msg) => (
+							<AIChatMessage
+								key={msg.id}
+								message={msg}
+								onInsertSQL={onInsertSQL}
+							/>
+						))}
+					</>
+				)}
+				{error && (
+					<div
+						style={{
+							padding: "8px 12px",
+							background: "rgba(239, 68, 68, 0.1)",
+							border: "1px solid rgba(239, 68, 68, 0.3)",
+							borderRadius: "6px",
+							color: "#ef4444",
+							fontSize: "12px",
+							marginTop: "8px",
+						}}
+					>
+						{error}
+					</div>
+				)}
+				<div ref={messagesEndRef} />
+			</div>
+
+			{/* Quick actions */}
+			{hasApiKey && messages.length === 0 && (
+				<div
+					style={{
+						padding: "0 16px 8px",
+						display: "flex",
+						gap: "6px",
+						flexWrap: "wrap",
+					}}
+				>
+					{[
+						{ label: "Explain", prompt: "Explain this SQL query:" },
+						{ label: "Fix Error", prompt: "Fix the error in this SQL:" },
+						{ label: "Optimize", prompt: "Optimize this SQL query:" },
+					].map((action) => (
+						<button
+							key={action.label}
+							onClick={() => handleQuickAction(action.prompt)}
+							disabled={isStreaming || !editorContent?.trim()}
+							style={{
+								background: "var(--bg-tertiary)",
+								border: "1px solid var(--border-light)",
+								borderRadius: "14px",
+								padding: "4px 12px",
+								fontSize: "12px",
+								color: "var(--text-secondary)",
+								cursor:
+									isStreaming || !editorContent?.trim()
+										? "not-allowed"
+										: "pointer",
+								opacity: isStreaming || !editorContent?.trim() ? 0.5 : 1,
+								transition: "all 0.2s",
+							}}
+							onMouseEnter={(e) => {
+								if (!isStreaming && editorContent?.trim()) {
+									e.currentTarget.style.background = "var(--bg-quaternary)";
+									e.currentTarget.style.color = "var(--text-primary)";
+								}
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.background = "var(--bg-tertiary)";
+								e.currentTarget.style.color = "var(--text-secondary)";
+							}}
+						>
+							{action.label}
+						</button>
+					))}
+				</div>
+			)}
+
+			{/* Input area */}
+			<div
+				style={{
+					padding: "12px 16px",
+					borderTop: "1px solid var(--border-light)",
+					background: "var(--bg-secondary)",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						gap: "8px",
+						alignItems: "flex-end",
+					}}
+				>
+					<textarea
+						ref={textareaRef}
+						value={input}
+						onChange={(e) => setInput(e.target.value)}
+						onKeyDown={handleKeyDown}
+						placeholder={
+							hasApiKey === false
+								? "Configure an API key first..."
+								: "Ask about SQL..."
+						}
+						disabled={hasApiKey === false}
+						rows={1}
+						style={{
+							flex: 1,
+							resize: "none",
+							background: "var(--bg-primary)",
+							color: "var(--text-primary)",
+							border: "1px solid var(--border-light)",
+							borderRadius: "8px",
+							padding: "8px 12px",
+							fontSize: "13px",
+							fontFamily: "inherit",
+							lineHeight: "1.4",
+							maxHeight: "120px",
+							overflowY: "auto",
+							outline: "none",
+						}}
+						onInput={(e) => {
+							const target = e.currentTarget;
+							target.style.height = "auto";
+							target.style.height =
+								Math.min(target.scrollHeight, 120) + "px";
+						}}
+						onFocus={(e) => {
+							e.currentTarget.style.borderColor = "var(--accent)";
+						}}
+						onBlur={(e) => {
+							e.currentTarget.style.borderColor = "var(--border-light)";
+						}}
+					/>
+					{isStreaming ? (
+						<button
+							onClick={stopStreaming}
+							title="Stop generating"
+							style={{
+								background: "#ef4444",
+								color: "white",
+								border: "none",
+								borderRadius: "8px",
+								width: "36px",
+								height: "36px",
+								cursor: "pointer",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								flexShrink: 0,
+							}}
+						>
+							<StopIcon size={16} />
+						</button>
+					) : (
+						<button
+							onClick={handleSend}
+							disabled={!input.trim() || hasApiKey === false}
+							title="Send message"
+							style={{
+								background:
+									input.trim() && hasApiKey !== false
+										? "var(--accent)"
+										: "var(--bg-tertiary)",
+								color:
+									input.trim() && hasApiKey !== false
+										? "white"
+										: "var(--text-muted)",
+								border: "none",
+								borderRadius: "8px",
+								width: "36px",
+								height: "36px",
+								cursor:
+									input.trim() && hasApiKey !== false
+										? "pointer"
+										: "not-allowed",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								flexShrink: 0,
+								transition: "all 0.2s",
+							}}
+						>
+							<SendIcon size={16} />
+						</button>
+					)}
+				</div>
+				<div
+					style={{
+						fontSize: "10px",
+						color: "var(--text-muted)",
+						marginTop: "4px",
+						textAlign: "right",
+					}}
+				>
+					{provider.displayName} - {useAIChatStore.getState().selectedModels[activeProvider]}
+				</div>
+			</div>
+
+			{/* Blink animation for streaming cursor */}
+			<style>{`
+				@keyframes blink {
+					50% { opacity: 0; }
+				}
+			`}</style>
+		</div>
+	);
+}
+
+function WelcomeCard({
+	activeProvider,
+	onSelectProvider,
+}: {
+	activeProvider: AIProviderType;
+	onSelectProvider: (p: AIProviderType) => void;
+}) {
+	const providers: { type: AIProviderType; name: string; desc: string; free: boolean }[] = [
+		{ type: "gemini", name: "Google Gemini", desc: "Free - 15 req/min", free: true },
+		{ type: "groq", name: "Groq", desc: "Free - 30 req/min", free: true },
+		{ type: "openai", name: "OpenAI", desc: "Paid - GPT-4o", free: false },
+		{ type: "anthropic", name: "Anthropic", desc: "Paid - Claude", free: false },
+	];
+
+	const apiKeyUrls: Record<AIProviderType, string> = {
+		gemini: "https://aistudio.google.com/app/apikey",
+		groq: "https://console.groq.com/keys",
+		openai: "https://platform.openai.com/api-keys",
+		anthropic: "https://console.anthropic.com/settings/keys",
+	};
+
+	return (
+		<div
+			style={{
+				textAlign: "center",
+				padding: "32px 16px",
+			}}
+		>
+			<SparklesIcon
+				size={40}
+				style={{ marginBottom: "16px", opacity: 0.4 }}
+			/>
+			<h4
+				style={{
+					margin: "0 0 8px",
+					fontSize: "16px",
+					fontWeight: 600,
+				}}
+			>
+				Get Started with AI SQL Assistant
+			</h4>
+			<p
+				style={{
+					color: "var(--text-muted)",
+					fontSize: "13px",
+					margin: "0 0 20px",
+					lineHeight: "1.5",
+				}}
+			>
+				Choose a provider and add your API key.
+				<br />
+				Gemini and Groq offer free tiers.
+			</p>
+
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					gap: "8px",
+					textAlign: "left",
+				}}
+			>
+				{providers.map((p) => (
+					<button
+						key={p.type}
+						onClick={() => onSelectProvider(p.type)}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "space-between",
+							padding: "10px 14px",
+							background:
+								activeProvider === p.type
+									? "var(--bg-quaternary)"
+									: "var(--bg-secondary)",
+							border:
+								activeProvider === p.type
+									? "1px solid var(--accent)"
+									: "1px solid var(--border-light)",
+							borderRadius: "8px",
+							cursor: "pointer",
+							color: "var(--text-primary)",
+							fontSize: "13px",
+							transition: "all 0.2s",
+						}}
+					>
+						<div>
+							<div style={{ fontWeight: 500 }}>{p.name}</div>
+							<div
+								style={{
+									fontSize: "11px",
+									color: p.free ? "#10b981" : "var(--text-muted)",
+									marginTop: "2px",
+								}}
+							>
+								{p.desc}
+							</div>
+						</div>
+						<a
+							href={apiKeyUrls[p.type]}
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={(e) => e.stopPropagation()}
+							style={{
+								fontSize: "11px",
+								color: "var(--accent)",
+								textDecoration: "none",
+							}}
+						>
+							Get Key
+						</a>
+					</button>
+				))}
+			</div>
+
+			<p
+				style={{
+					color: "var(--text-muted)",
+					fontSize: "11px",
+					margin: "16px 0 0",
+				}}
+			>
+				Add your API key in Settings &gt; AI tab
+			</p>
+		</div>
+	);
+}
+
+function EmptyState() {
+	return (
+		<div
+			style={{
+				textAlign: "center",
+				padding: "48px 16px",
+				color: "var(--text-muted)",
+			}}
+		>
+			<SparklesIcon
+				size={48}
+				style={{ marginBottom: "16px", opacity: 0.2 }}
+			/>
+			<div style={{ fontSize: "14px", marginBottom: "6px" }}>
+				Ask anything about SQL
+			</div>
+			<div style={{ fontSize: "12px" }}>
+				Write queries, explain code, fix errors, or optimize performance
+			</div>
+		</div>
+	);
+}

--- a/apps/web-client/src/components/EditorPane.tsx
+++ b/apps/web-client/src/components/EditorPane.tsx
@@ -91,6 +91,7 @@ export interface EditorPaneHandle {
 	getSelection: () => string;
 	getCursorPosition: () => number;
 	setCursorPosition: (offset: number) => void;
+	insertAtCursor: (text: string) => void;
 	focus: () => void;
 }
 
@@ -221,6 +222,32 @@ const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
 				const position = model.getPositionAt(offset);
 				editor.setPosition(position);
 				editor.revealPositionInCenterIfOutsideViewport(position, monaco.editor.ScrollType.Smooth);
+			},
+			insertAtCursor: (text: string) => {
+				const editor = editorInstanceRef.current;
+				if (!editor) return;
+				const position = editor.getPosition();
+				if (!position) return;
+				editor.executeEdits("ai-insert", [
+					{
+						range: new monaco.Range(
+							position.lineNumber,
+							position.column,
+							position.lineNumber,
+							position.column,
+						),
+						text,
+					},
+				]);
+				// Move cursor to end of inserted text
+				const model = editor.getModel();
+				if (model) {
+					const newPosition = model.getPositionAt(
+						model.getOffsetAt(position) + text.length,
+					);
+					editor.setPosition(newPosition);
+				}
+				editor.focus();
 			},
 			focus: () => {
 				if (!editorInstanceRef.current) return;

--- a/apps/web-client/src/components/Header.tsx
+++ b/apps/web-client/src/components/Header.tsx
@@ -9,6 +9,7 @@ import {
 	PlayIcon,
 	SaveIcon,
 	SettingsIcon,
+	SparklesIcon,
 	StopIcon,
 	XCircleIcon,
 } from "./Icons";
@@ -50,6 +51,10 @@ interface HeaderProps {
 	showSettings: boolean;
 	onToggleSettings: () => void;
 	onOpenServerSettings?: () => void;
+
+	// AI Chat
+	showAIChat?: boolean;
+	onToggleAIChat?: () => void;
 }
 
 export default function Header({
@@ -75,6 +80,8 @@ export default function Header({
 	showSettings: _showSettings,
 	onToggleSettings,
 	onOpenServerSettings,
+	showAIChat: _showAIChat,
+	onToggleAIChat,
 }: HeaderProps) {
 	const { isHttpMode } = useMode();
 	const isDisabled =
@@ -233,6 +240,18 @@ export default function Header({
 						</option>
 					</select>
 				</div>
+				{onToggleAIChat && (
+					<button
+						onClick={onToggleAIChat}
+						className="file-button"
+						title="AI SQL Assistant (Cmd/Ctrl+Shift+A)"
+						aria-label="Toggle AI SQL Assistant"
+						style={{ display: "flex", alignItems: "center", gap: "6px" }}
+					>
+						<SparklesIcon size={16} aria-hidden="true" />
+						AI
+					</button>
+				)}
 				<ThemeToggle />
 				<button
 					className="settings-button"

--- a/apps/web-client/src/components/Icons.tsx
+++ b/apps/web-client/src/components/Icons.tsx
@@ -1268,3 +1268,58 @@ export function GlobeIcon({
         </svg>
     );
 }
+
+// Sparkles icon for AI Assistant
+export function SparklesIcon({
+    size = 16,
+    color = "currentColor",
+    className,
+    style,
+}: IconProps) {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            style={style}
+        >
+            <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z"></path>
+            <path d="M5 3v4"></path>
+            <path d="M3 5h4"></path>
+            <path d="M19 17v4"></path>
+            <path d="M17 19h4"></path>
+        </svg>
+    );
+}
+
+// Send icon for chat
+export function SendIcon({
+    size = 16,
+    color = "currentColor",
+    className,
+    style,
+}: IconProps) {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            style={style}
+        >
+            <line x1="22" y1="2" x2="11" y2="13"></line>
+            <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+        </svg>
+    );
+}

--- a/apps/web-client/src/components/SettingsModal.tsx
+++ b/apps/web-client/src/components/SettingsModal.tsx
@@ -3,6 +3,7 @@ import { DatabaseIcon } from "./Icons";
 import { useMode } from "../hooks/useMode";
 import {
 	AboutSettings,
+	AISettings,
 	AppearanceSettings,
 	ConnectionsSettings,
 	FormattingSettings,
@@ -10,7 +11,7 @@ import {
 	ServerSettings,
 } from "./settings";
 
-export type SettingsTab = "appearance" | "connections" | "formatting" | "help" | "about" | "server";
+export type SettingsTab = "appearance" | "connections" | "formatting" | "help" | "about" | "server" | "ai";
 
 interface SettingsModalProps {
 	fontSize: number;
@@ -224,6 +225,39 @@ export default function SettingsModal({
 					Formatting
 				</button>
 				<button
+					onClick={() => setActiveTab("ai")}
+					style={{
+						padding: "12px 24px",
+						background:
+							activeTab === "ai" ? "var(--accent)" : "transparent",
+						color:
+							activeTab === "ai" ? "white" : "var(--text-secondary)",
+						border: "none",
+						borderRadius: "8px 8px 0 0",
+						cursor: "pointer",
+						fontWeight: activeTab === "ai" ? "600" : "normal",
+						fontSize: "14px",
+						transition: "all 0.2s",
+						display: "flex",
+						alignItems: "center",
+						gap: "8px",
+					}}
+				>
+					<svg
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z"></path>
+					</svg>
+					AI
+				</button>
+				<button
 					onClick={() => setActiveTab("help")}
 					style={{
 						padding: "12px 24px",
@@ -345,6 +379,9 @@ export default function SettingsModal({
 
 				{/* About Tab */}
 				{activeTab === "about" && <AboutSettings />}
+
+				{/* AI Tab */}
+				{activeTab === "ai" && <AISettings showToast={showToast} />}
 
 				{/* Server Tab - HTTP mode only */}
 				{activeTab === "server" && <ServerSettings />}

--- a/apps/web-client/src/components/settings/AISettings.tsx
+++ b/apps/web-client/src/components/settings/AISettings.tsx
@@ -47,7 +47,9 @@ export default function AISettings({ showToast }: AISettingsProps) {
 		groq: false,
 	});
 	const [testing, setTesting] = useState(false);
-	const [testResult, setTestResult] = useState<"success" | "error" | null>(null);
+	const [testResult, setTestResult] = useState<"success" | "error" | null>(
+		null,
+	);
 	const testAbortRef = useRef<AbortController | null>(null);
 
 	// Abort any in-flight test on unmount
@@ -71,7 +73,10 @@ export default function AISettings({ showToast }: AISettingsProps) {
 
 	const handleSaveKey = useCallback(async () => {
 		if (!apiKey.trim()) return;
-		await aiCredentialStore.save(getCredentialKey(activeProvider), apiKey.trim());
+		await aiCredentialStore.save(
+			getCredentialKey(activeProvider),
+			apiKey.trim(),
+		);
 		setSavedKeys((prev) => ({ ...prev, [activeProvider]: true }));
 		setApiKey("");
 		showToast?.("API key saved", "success", 2000);
@@ -109,11 +114,15 @@ export default function AISettings({ showToast }: AISettingsProps) {
 			];
 
 			let gotResponse = false;
-			for await (const chunk of provider.streamChat(testMessages, {
-				apiKey: key,
-				model,
-				maxTokens: 10,
-			}, controller.signal)) {
+			for await (const chunk of provider.streamChat(
+				testMessages,
+				{
+					apiKey: key,
+					model,
+					maxTokens: 10,
+				},
+				controller.signal,
+			)) {
 				if (chunk.type === "text") {
 					gotResponse = true;
 					break;
@@ -133,11 +142,7 @@ export default function AISettings({ showToast }: AISettingsProps) {
 		} catch (err) {
 			if ((err as Error).name === "AbortError") return;
 			setTestResult("error");
-			showToast?.(
-				`Test failed: ${(err as Error).message}`,
-				"error",
-				4000,
-			);
+			showToast?.(`Test failed: ${(err as Error).message}`, "error", 4000);
 		} finally {
 			testAbortRef.current = null;
 			setTesting(false);
@@ -372,9 +377,7 @@ export default function AISettings({ showToast }: AISettingsProps) {
 				<label style={labelStyle}>Model</label>
 				<select
 					value={selectedModels[activeProvider]}
-					onChange={(e) =>
-						setSelectedModel(activeProvider, e.target.value)
-					}
+					onChange={(e) => setSelectedModel(activeProvider, e.target.value)}
 					style={{
 						width: "100%",
 						padding: "8px 12px",
@@ -442,16 +445,30 @@ export default function AISettings({ showToast }: AISettingsProps) {
 					color: "var(--text-muted)",
 				}}
 			>
-				<div style={{ fontWeight: 500, marginBottom: "4px", color: "var(--text-secondary)" }}>
+				<div
+					style={{
+						fontWeight: 500,
+						marginBottom: "4px",
+						color: "var(--text-secondary)",
+					}}
+				>
 					Free tier options
 				</div>
-				<div><strong>Google Gemini</strong> - 15 requests/min, no credit card needed</div>
-				<div><strong>Groq</strong> - 30 requests/min, free for smaller models</div>
-				<div style={{ marginTop: "4px", fontSize: "11px" }}>
-					API keys are stored locally in your browser (obfuscated, not encrypted). They are never sent to any server except the AI provider you choose.
+				<div>
+					<strong>Google Gemini</strong> - 15 requests/min, no credit card
+					needed
+				</div>
+				<div>
+					<strong>Groq</strong> - 30 requests/min, free for smaller models
 				</div>
 				<div style={{ marginTop: "4px", fontSize: "11px" }}>
-					Note: Gemini sends the API key as a URL parameter (required by their browser API). Other providers use secure HTTP headers.
+					API keys are encrypted locally in your browser (AES-GCM with a
+					device-bound key). They are never sent to any server except the AI
+					provider you choose.
+				</div>
+				<div style={{ marginTop: "4px", fontSize: "11px" }}>
+					Note: Gemini sends the API key as a URL parameter (required by their
+					browser API). Other providers use secure HTTP headers.
 				</div>
 			</div>
 		</div>

--- a/apps/web-client/src/components/settings/AISettings.tsx
+++ b/apps/web-client/src/components/settings/AISettings.tsx
@@ -1,0 +1,442 @@
+/**
+ * AISettings Component
+ * Settings tab for configuring AI providers, API keys, and models.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { CredentialStore } from "@ide/storage";
+import {
+	type AIProviderType,
+	getAllProviderTypes,
+	getCredentialKey,
+	getProvider,
+} from "../../services/ai";
+import { useAIChatStore } from "../../stores/aiChatStore";
+import { CheckIcon, KeyIcon, TrashIcon } from "../Icons";
+
+interface AISettingsProps {
+	showToast?: (
+		message: string,
+		type?: "success" | "error" | "info" | "warning",
+		duration?: number,
+	) => void;
+}
+
+const credentialStore = new CredentialStore();
+
+const apiKeyUrls: Record<AIProviderType, string> = {
+	gemini: "https://aistudio.google.com/app/apikey",
+	groq: "https://console.groq.com/keys",
+	openai: "https://platform.openai.com/api-keys",
+	anthropic: "https://console.anthropic.com/settings/keys",
+};
+
+export default function AISettings({ showToast }: AISettingsProps) {
+	const {
+		activeProvider,
+		selectedModels,
+		messages,
+		setActiveProvider,
+		setSelectedModel,
+		clearMessages,
+	} = useAIChatStore();
+
+	const [apiKey, setApiKey] = useState("");
+	const [savedKeys, setSavedKeys] = useState<Record<AIProviderType, boolean>>({
+		openai: false,
+		anthropic: false,
+		gemini: false,
+		groq: false,
+	});
+	const [testing, setTesting] = useState(false);
+	const [testResult, setTestResult] = useState<"success" | "error" | null>(null);
+
+	// Load which providers have saved keys
+	useEffect(() => {
+		(async () => {
+			const result: Record<string, boolean> = {};
+			for (const type of getAllProviderTypes()) {
+				const key = await credentialStore.load(getCredentialKey(type));
+				result[type] = !!key;
+			}
+			setSavedKeys(result as Record<AIProviderType, boolean>);
+		})();
+	}, []);
+
+	const handleSaveKey = useCallback(async () => {
+		if (!apiKey.trim()) return;
+		await credentialStore.save(getCredentialKey(activeProvider), apiKey.trim());
+		setSavedKeys((prev) => ({ ...prev, [activeProvider]: true }));
+		setApiKey("");
+		showToast?.("API key saved", "success", 2000);
+	}, [apiKey, activeProvider, showToast]);
+
+	const handleRemoveKey = useCallback(async () => {
+		await credentialStore.save(getCredentialKey(activeProvider), null);
+		setSavedKeys((prev) => ({ ...prev, [activeProvider]: false }));
+		showToast?.("API key removed", "info", 2000);
+	}, [activeProvider, showToast]);
+
+	const handleTestKey = useCallback(async () => {
+		setTesting(true);
+		setTestResult(null);
+		try {
+			const key = (await credentialStore.load(
+				getCredentialKey(activeProvider),
+			)) as string | null;
+			if (!key) {
+				setTestResult("error");
+				showToast?.("No API key saved", "error", 2000);
+				return;
+			}
+
+			const provider = getProvider(activeProvider);
+			const model = selectedModels[activeProvider];
+			const testMessages = [
+				{ role: "user" as const, content: "Say 'OK' and nothing else." },
+			];
+
+			let gotResponse = false;
+			for await (const chunk of provider.streamChat(testMessages, {
+				apiKey: key,
+				model,
+				maxTokens: 10,
+			})) {
+				if (chunk.type === "text") {
+					gotResponse = true;
+					break;
+				}
+				if (chunk.type === "error") {
+					throw new Error(chunk.error);
+				}
+			}
+
+			if (gotResponse) {
+				setTestResult("success");
+				showToast?.("API key is valid", "success", 2000);
+			} else {
+				setTestResult("error");
+				showToast?.("No response received", "error", 2000);
+			}
+		} catch (err) {
+			setTestResult("error");
+			showToast?.(
+				`Test failed: ${(err as Error).message}`,
+				"error",
+				4000,
+			);
+		} finally {
+			setTesting(false);
+		}
+	}, [activeProvider, selectedModels, showToast]);
+
+	const provider = getProvider(activeProvider);
+
+	const sectionStyle: React.CSSProperties = {
+		marginBottom: "24px",
+	};
+
+	const labelStyle: React.CSSProperties = {
+		display: "block",
+		fontSize: "13px",
+		fontWeight: 500,
+		marginBottom: "6px",
+		color: "var(--text-secondary)",
+	};
+
+	return (
+		<div style={{ padding: "0 4px" }}>
+			<h3
+				style={{
+					margin: "0 0 20px",
+					fontSize: "18px",
+					fontWeight: 600,
+				}}
+			>
+				AI Assistant
+			</h3>
+
+			{/* Provider Selection */}
+			<div style={sectionStyle}>
+				<label style={labelStyle}>Provider</label>
+				<div
+					style={{
+						display: "grid",
+						gridTemplateColumns: "1fr 1fr",
+						gap: "8px",
+					}}
+				>
+					{getAllProviderTypes().map((type) => {
+						const p = getProvider(type);
+						const isFree = p.models.some((m) => m.isFree);
+						const hasSavedKey = savedKeys[type];
+						return (
+							<button
+								key={type}
+								onClick={() => setActiveProvider(type)}
+								style={{
+									padding: "10px 12px",
+									background:
+										activeProvider === type
+											? "var(--bg-quaternary)"
+											: "var(--bg-secondary)",
+									border:
+										activeProvider === type
+											? "2px solid var(--accent)"
+											: "1px solid var(--border-light)",
+									borderRadius: "8px",
+									cursor: "pointer",
+									color: "var(--text-primary)",
+									textAlign: "left",
+									fontSize: "13px",
+									position: "relative",
+									transition: "all 0.2s",
+								}}
+							>
+								<div style={{ fontWeight: 500 }}>{p.displayName}</div>
+								<div
+									style={{
+										fontSize: "11px",
+										color: isFree ? "#10b981" : "var(--text-muted)",
+										marginTop: "2px",
+									}}
+								>
+									{isFree ? "Free tier available" : "Paid"}
+								</div>
+								{hasSavedKey && (
+									<div
+										style={{
+											position: "absolute",
+											top: "6px",
+											right: "8px",
+										}}
+									>
+										<CheckIcon size={12} color="#10b981" />
+									</div>
+								)}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+
+			{/* API Key */}
+			<div style={sectionStyle}>
+				<label style={labelStyle}>
+					API Key
+					{savedKeys[activeProvider] && (
+						<span
+							style={{
+								color: "#10b981",
+								fontWeight: "normal",
+								marginLeft: "8px",
+								fontSize: "11px",
+							}}
+						>
+							Configured
+						</span>
+					)}
+				</label>
+				{savedKeys[activeProvider] ? (
+					<div style={{ display: "flex", gap: "8px" }}>
+						<button
+							onClick={handleTestKey}
+							disabled={testing}
+							style={{
+								flex: 1,
+								padding: "8px 12px",
+								background:
+									testResult === "success"
+										? "rgba(16, 185, 129, 0.1)"
+										: testResult === "error"
+											? "rgba(239, 68, 68, 0.1)"
+											: "var(--bg-tertiary)",
+								border: `1px solid ${
+									testResult === "success"
+										? "#10b981"
+										: testResult === "error"
+											? "#ef4444"
+											: "var(--border-light)"
+								}`,
+								borderRadius: "6px",
+								color: "var(--text-primary)",
+								fontSize: "13px",
+								cursor: testing ? "wait" : "pointer",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								gap: "6px",
+							}}
+						>
+							<KeyIcon size={14} />
+							{testing
+								? "Testing..."
+								: testResult === "success"
+									? "Key is valid"
+									: testResult === "error"
+										? "Test failed"
+										: "Test Key"}
+						</button>
+						<button
+							onClick={handleRemoveKey}
+							title="Remove API key"
+							style={{
+								padding: "8px 12px",
+								background: "var(--bg-tertiary)",
+								border: "1px solid var(--border-light)",
+								borderRadius: "6px",
+								color: "#ef4444",
+								cursor: "pointer",
+								display: "flex",
+								alignItems: "center",
+								gap: "4px",
+								fontSize: "13px",
+							}}
+						>
+							<TrashIcon size={14} />
+							Remove
+						</button>
+					</div>
+				) : (
+					<div style={{ display: "flex", gap: "8px" }}>
+						<input
+							type="password"
+							value={apiKey}
+							onChange={(e) => setApiKey(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") handleSaveKey();
+							}}
+							placeholder="Paste your API key..."
+							style={{
+								flex: 1,
+								padding: "8px 12px",
+								background: "var(--bg-primary)",
+								color: "var(--text-primary)",
+								border: "1px solid var(--border-light)",
+								borderRadius: "6px",
+								fontSize: "13px",
+								outline: "none",
+							}}
+						/>
+						<button
+							onClick={handleSaveKey}
+							disabled={!apiKey.trim()}
+							style={{
+								padding: "8px 16px",
+								background: apiKey.trim()
+									? "var(--accent)"
+									: "var(--bg-tertiary)",
+								color: apiKey.trim() ? "white" : "var(--text-muted)",
+								border: "none",
+								borderRadius: "6px",
+								fontSize: "13px",
+								cursor: apiKey.trim() ? "pointer" : "not-allowed",
+							}}
+						>
+							Save
+						</button>
+					</div>
+				)}
+				<a
+					href={apiKeyUrls[activeProvider]}
+					target="_blank"
+					rel="noopener noreferrer"
+					style={{
+						display: "inline-block",
+						marginTop: "6px",
+						fontSize: "12px",
+						color: "var(--accent)",
+						textDecoration: "none",
+					}}
+				>
+					Get a {provider.displayName} API key
+				</a>
+			</div>
+
+			{/* Model Selection */}
+			<div style={sectionStyle}>
+				<label style={labelStyle}>Model</label>
+				<select
+					value={selectedModels[activeProvider]}
+					onChange={(e) =>
+						setSelectedModel(activeProvider, e.target.value)
+					}
+					style={{
+						width: "100%",
+						padding: "8px 12px",
+						background: "var(--bg-primary)",
+						color: "var(--text-primary)",
+						border: "1px solid var(--border-light)",
+						borderRadius: "6px",
+						fontSize: "13px",
+						cursor: "pointer",
+					}}
+				>
+					{provider.models.map((m) => (
+						<option key={m.id} value={m.id}>
+							{m.name}
+							{m.isFree ? " (Free)" : ""}
+						</option>
+					))}
+				</select>
+			</div>
+
+			{/* Chat History */}
+			<div style={sectionStyle}>
+				<label style={labelStyle}>Chat History</label>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+					}}
+				>
+					<span style={{ fontSize: "13px", color: "var(--text-muted)" }}>
+						{messages.length} message{messages.length !== 1 ? "s" : ""}
+					</span>
+					{messages.length > 0 && (
+						<button
+							onClick={() => {
+								clearMessages();
+								showToast?.("Chat history cleared", "info", 2000);
+							}}
+							style={{
+								padding: "6px 12px",
+								background: "var(--bg-tertiary)",
+								border: "1px solid var(--border-light)",
+								borderRadius: "6px",
+								color: "var(--text-muted)",
+								fontSize: "12px",
+								cursor: "pointer",
+							}}
+						>
+							Clear History
+						</button>
+					)}
+				</div>
+			</div>
+
+			{/* Free Tier Info */}
+			<div
+				style={{
+					padding: "12px 14px",
+					background: "var(--bg-secondary)",
+					borderRadius: "8px",
+					border: "1px solid var(--border-light)",
+					fontSize: "12px",
+					lineHeight: "1.6",
+					color: "var(--text-muted)",
+				}}
+			>
+				<div style={{ fontWeight: 500, marginBottom: "4px", color: "var(--text-secondary)" }}>
+					Free tier options
+				</div>
+				<div><strong>Google Gemini</strong> - 15 requests/min, no credit card needed</div>
+				<div><strong>Groq</strong> - 30 requests/min, free for smaller models</div>
+				<div style={{ marginTop: "4px", fontSize: "11px" }}>
+					API keys are stored locally in your browser. They are never sent to any server except the AI provider you choose.
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web-client/src/components/settings/AISettings.tsx
+++ b/apps/web-client/src/components/settings/AISettings.tsx
@@ -3,10 +3,10 @@
  * Settings tab for configuring AI providers, API keys, and models.
  */
 
-import { useCallback, useEffect, useState } from "react";
-import { CredentialStore } from "@ide/storage";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type AIProviderType,
+	aiCredentialStore,
 	getAllProviderTypes,
 	getCredentialKey,
 	getProvider,
@@ -21,8 +21,6 @@ interface AISettingsProps {
 		duration?: number,
 	) => void;
 }
-
-const credentialStore = new CredentialStore();
 
 const apiKeyUrls: Record<AIProviderType, string> = {
 	gemini: "https://aistudio.google.com/app/apikey",
@@ -50,13 +48,21 @@ export default function AISettings({ showToast }: AISettingsProps) {
 	});
 	const [testing, setTesting] = useState(false);
 	const [testResult, setTestResult] = useState<"success" | "error" | null>(null);
+	const testAbortRef = useRef<AbortController | null>(null);
+
+	// Abort any in-flight test on unmount
+	useEffect(() => {
+		return () => {
+			testAbortRef.current?.abort();
+		};
+	}, []);
 
 	// Load which providers have saved keys
 	useEffect(() => {
 		(async () => {
 			const result: Record<string, boolean> = {};
 			for (const type of getAllProviderTypes()) {
-				const key = await credentialStore.load(getCredentialKey(type));
+				const key = await aiCredentialStore.load(getCredentialKey(type));
 				result[type] = !!key;
 			}
 			setSavedKeys(result as Record<AIProviderType, boolean>);
@@ -65,14 +71,14 @@ export default function AISettings({ showToast }: AISettingsProps) {
 
 	const handleSaveKey = useCallback(async () => {
 		if (!apiKey.trim()) return;
-		await credentialStore.save(getCredentialKey(activeProvider), apiKey.trim());
+		await aiCredentialStore.save(getCredentialKey(activeProvider), apiKey.trim());
 		setSavedKeys((prev) => ({ ...prev, [activeProvider]: true }));
 		setApiKey("");
 		showToast?.("API key saved", "success", 2000);
 	}, [apiKey, activeProvider, showToast]);
 
 	const handleRemoveKey = useCallback(async () => {
-		await credentialStore.save(getCredentialKey(activeProvider), null);
+		await aiCredentialStore.save(getCredentialKey(activeProvider), null);
 		setSavedKeys((prev) => ({ ...prev, [activeProvider]: false }));
 		showToast?.("API key removed", "info", 2000);
 	}, [activeProvider, showToast]);
@@ -80,8 +86,14 @@ export default function AISettings({ showToast }: AISettingsProps) {
 	const handleTestKey = useCallback(async () => {
 		setTesting(true);
 		setTestResult(null);
+
+		// Abort any previous test
+		testAbortRef.current?.abort();
+		const controller = new AbortController();
+		testAbortRef.current = controller;
+
 		try {
-			const key = (await credentialStore.load(
+			const key = (await aiCredentialStore.load(
 				getCredentialKey(activeProvider),
 			)) as string | null;
 			if (!key) {
@@ -101,7 +113,7 @@ export default function AISettings({ showToast }: AISettingsProps) {
 				apiKey: key,
 				model,
 				maxTokens: 10,
-			})) {
+			}, controller.signal)) {
 				if (chunk.type === "text") {
 					gotResponse = true;
 					break;
@@ -119,6 +131,7 @@ export default function AISettings({ showToast }: AISettingsProps) {
 				showToast?.("No response received", "error", 2000);
 			}
 		} catch (err) {
+			if ((err as Error).name === "AbortError") return;
 			setTestResult("error");
 			showToast?.(
 				`Test failed: ${(err as Error).message}`,
@@ -126,6 +139,7 @@ export default function AISettings({ showToast }: AISettingsProps) {
 				4000,
 			);
 		} finally {
+			testAbortRef.current = null;
 			setTesting(false);
 		}
 	}, [activeProvider, selectedModels, showToast]);
@@ -434,7 +448,10 @@ export default function AISettings({ showToast }: AISettingsProps) {
 				<div><strong>Google Gemini</strong> - 15 requests/min, no credit card needed</div>
 				<div><strong>Groq</strong> - 30 requests/min, free for smaller models</div>
 				<div style={{ marginTop: "4px", fontSize: "11px" }}>
-					API keys are stored locally in your browser. They are never sent to any server except the AI provider you choose.
+					API keys are stored locally in your browser (obfuscated, not encrypted). They are never sent to any server except the AI provider you choose.
+				</div>
+				<div style={{ marginTop: "4px", fontSize: "11px" }}>
+					Note: Gemini sends the API key as a URL parameter (required by their browser API). Other providers use secure HTTP headers.
 				</div>
 			</div>
 		</div>

--- a/apps/web-client/src/components/settings/index.ts
+++ b/apps/web-client/src/components/settings/index.ts
@@ -2,6 +2,7 @@
  * Settings components exports
  */
 export { default as AboutSettings } from "./AboutSettings";
+export { default as AISettings } from "./AISettings";
 export { default as AppearanceSettings } from "./AppearanceSettings";
 export { default as ConnectionsSettings } from "./ConnectionsSettings";
 export { default as FormattingSettings } from "./FormattingSettings";

--- a/apps/web-client/src/containers/DialogsContainer.tsx
+++ b/apps/web-client/src/containers/DialogsContainer.tsx
@@ -39,7 +39,7 @@ interface DialogsContainerProps {
 	showAIChat?: boolean;
 	onCloseAIChat?: () => void;
 	onInsertSQL?: (sql: string) => void;
-	editorContent?: string;
+	getEditorContent?: () => string;
 }
 
 export function DialogsContainer({
@@ -65,7 +65,7 @@ export function DialogsContainer({
 	showAIChat,
 	onCloseAIChat,
 	onInsertSQL,
-	editorContent,
+	getEditorContent,
 }: DialogsContainerProps) {
 	return (
 		<>
@@ -91,7 +91,7 @@ export function DialogsContainer({
 				<AIChatPanel
 					onClose={onCloseAIChat}
 					onInsertSQL={onInsertSQL}
-					editorContent={editorContent}
+					getEditorContent={getEditorContent}
 				/>
 			)}
 

--- a/apps/web-client/src/containers/DialogsContainer.tsx
+++ b/apps/web-client/src/containers/DialogsContainer.tsx
@@ -1,3 +1,4 @@
+import { AIChatPanel } from "../components/AIChatPanel";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { ExamplesPanel } from "../components/ExamplesPanel";
 import { FileConflictDialog } from "../components/FileConflictDialog";
@@ -34,6 +35,11 @@ interface DialogsContainerProps {
 	onConflictReload: () => void;
 	onConflictSaveAs: () => void;
 	onCancelConflict: () => void;
+	// AI Chat Panel
+	showAIChat?: boolean;
+	onCloseAIChat?: () => void;
+	onInsertSQL?: (sql: string) => void;
+	editorContent?: string;
 }
 
 export function DialogsContainer({
@@ -56,6 +62,10 @@ export function DialogsContainer({
 	onConflictReload,
 	onConflictSaveAs,
 	onCancelConflict,
+	showAIChat,
+	onCloseAIChat,
+	onInsertSQL,
+	editorContent,
 }: DialogsContainerProps) {
 	return (
 		<>
@@ -73,6 +83,15 @@ export function DialogsContainer({
 					history={toastHistory}
 					onClose={onCloseToastHistory}
 					onClear={onClearHistory}
+				/>
+			)}
+
+			{/* AI Chat Panel */}
+			{showAIChat && onCloseAIChat && (
+				<AIChatPanel
+					onClose={onCloseAIChat}
+					onInsertSQL={onInsertSQL}
+					editorContent={editorContent}
 				/>
 			)}
 

--- a/apps/web-client/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web-client/src/hooks/useKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ interface KeyboardShortcutsOptions {
 	onNextTab?: () => void;
 	onPrevTab?: () => void;
 	onRotateTheme?: () => void;
+	onToggleAIChat?: () => void;
 	canCloseTab: boolean;
 }
 
@@ -21,6 +22,7 @@ export function useKeyboardShortcuts({
 	onNextTab,
 	onPrevTab,
 	onRotateTheme,
+	onToggleAIChat,
 	canCloseTab,
 }: KeyboardShortcutsOptions) {
 	useEffect(() => {
@@ -75,9 +77,15 @@ export function useKeyboardShortcuts({
 				e.preventDefault();
 				onRotateTheme();
 			}
+
+			// Cmd/Ctrl+Shift+A: Toggle AI Chat
+			if (cmdOrCtrl && e.shiftKey && e.key.toLowerCase() === "a" && onToggleAIChat) {
+				e.preventDefault();
+				onToggleAIChat();
+			}
 		};
 
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [onNewTab, onCloseTab, onSave, onOpen, onToggleExplorer, onNextTab, onPrevTab, onRotateTheme, canCloseTab]);
+	}, [onNewTab, onCloseTab, onSave, onOpen, onToggleExplorer, onNextTab, onPrevTab, onRotateTheme, onToggleAIChat, canCloseTab]);
 }

--- a/apps/web-client/src/hooks/useUIVisibility.ts
+++ b/apps/web-client/src/hooks/useUIVisibility.ts
@@ -14,6 +14,7 @@ export function useUIVisibility() {
 	const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTab | undefined>(undefined);
 	const [showToastHistory, setShowToastHistory] = useState(false);
 	const [showExamples, setShowExamples] = useState(false);
+	const [showAIChat, setShowAIChat] = useState(false);
 	const [showExplorer, setShowExplorer] = useState(() => {
 		try {
 			const saved = localStorage.getItem("dbxlite-show-explorer");
@@ -61,6 +62,8 @@ export function useUIVisibility() {
 		setShowToastHistory,
 		showExamples,
 		setShowExamples,
+		showAIChat,
+		setShowAIChat,
 		showExplorer,
 		setShowExplorer,
 		toggleExplorer,

--- a/apps/web-client/src/services/ai/anthropic-provider.ts
+++ b/apps/web-client/src/services/ai/anthropic-provider.ts
@@ -17,7 +17,7 @@ export class AnthropicProvider implements AIProvider {
 	readonly displayName = "Anthropic";
 	readonly models: AIModelInfo[] = [
 		{ id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", contextWindow: 200000 },
-		{ id: "claude-haiku-4-20250414", name: "Claude Haiku 4", contextWindow: 200000 },
+		{ id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5", contextWindow: 200000 },
 	];
 
 	async *streamChat(

--- a/apps/web-client/src/services/ai/anthropic-provider.ts
+++ b/apps/web-client/src/services/ai/anthropic-provider.ts
@@ -16,8 +16,16 @@ export class AnthropicProvider implements AIProvider {
 	readonly type = "anthropic" as const;
 	readonly displayName = "Anthropic";
 	readonly models: AIModelInfo[] = [
-		{ id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", contextWindow: 200000 },
-		{ id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5", contextWindow: 200000 },
+		{
+			id: "claude-sonnet-4-6",
+			name: "Claude Sonnet 4.6",
+			contextWindow: 200000,
+		},
+		{
+			id: "claude-haiku-4-5-20251001",
+			name: "Claude Haiku 4.5",
+			contextWindow: 200000,
+		},
 	];
 
 	async *streamChat(
@@ -62,7 +70,10 @@ export class AnthropicProvider implements AIProvider {
 			} catch {
 				message = errorText;
 			}
-			yield { type: "error", error: `Anthropic API error (${response.status}): ${message}` };
+			yield {
+				type: "error",
+				error: `Anthropic API error (${response.status}): ${message}`,
+			};
 			return;
 		}
 
@@ -101,7 +112,10 @@ export class AnthropicProvider implements AIProvider {
 							yield { type: "done" };
 							return;
 						} else if (parsed.type === "error") {
-							yield { type: "error", error: parsed.error?.message || "Stream error" };
+							yield {
+								type: "error",
+								error: parsed.error?.message || "Stream error",
+							};
 							return;
 						}
 					} catch {

--- a/apps/web-client/src/services/ai/anthropic-provider.ts
+++ b/apps/web-client/src/services/ai/anthropic-provider.ts
@@ -1,0 +1,118 @@
+/**
+ * Anthropic Provider
+ * Handles Anthropic Messages API with SSE streaming.
+ * Requires `anthropic-dangerous-direct-browser-access` header for direct browser usage.
+ */
+
+import type {
+	AIMessage,
+	AIModelInfo,
+	AIProvider,
+	AIProviderConfig,
+	AIStreamChunk,
+} from "./types";
+
+export class AnthropicProvider implements AIProvider {
+	readonly type = "anthropic" as const;
+	readonly displayName = "Anthropic";
+	readonly models: AIModelInfo[] = [
+		{ id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4", contextWindow: 200000 },
+		{ id: "claude-haiku-4-20250414", name: "Claude Haiku 4", contextWindow: 200000 },
+	];
+
+	async *streamChat(
+		messages: AIMessage[],
+		config: AIProviderConfig,
+		signal?: AbortSignal,
+	): AsyncGenerator<AIStreamChunk> {
+		// Separate system message from conversation messages
+		const systemMessage = messages.find((m) => m.role === "system");
+		const conversationMessages = messages
+			.filter((m) => m.role !== "system")
+			.map((m) => ({ role: m.role, content: m.content }));
+
+		const body: Record<string, unknown> = {
+			model: config.model,
+			messages: conversationMessages,
+			max_tokens: config.maxTokens ?? 4096,
+			stream: true,
+		};
+		if (systemMessage) {
+			body.system = systemMessage.content;
+		}
+
+		const response = await fetch("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": config.apiKey,
+				"anthropic-version": "2023-06-01",
+				"anthropic-dangerous-direct-browser-access": "true",
+			},
+			body: JSON.stringify(body),
+			signal,
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text().catch(() => "Unknown error");
+			let message: string;
+			try {
+				const errorJson = JSON.parse(errorText);
+				message = errorJson.error?.message || errorText;
+			} catch {
+				message = errorText;
+			}
+			yield { type: "error", error: `Anthropic API error (${response.status}): ${message}` };
+			return;
+		}
+
+		const reader = response.body?.getReader();
+		if (!reader) {
+			yield { type: "error", error: "No response body" };
+			return;
+		}
+
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() || "";
+
+				for (const line of lines) {
+					const trimmed = line.trim();
+					if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+					const data = trimmed.slice(6);
+					try {
+						const parsed = JSON.parse(data);
+
+						if (parsed.type === "content_block_delta") {
+							const text = parsed.delta?.text;
+							if (text) {
+								yield { type: "text", text };
+							}
+						} else if (parsed.type === "message_stop") {
+							yield { type: "done" };
+							return;
+						} else if (parsed.type === "error") {
+							yield { type: "error", error: parsed.error?.message || "Stream error" };
+							return;
+						}
+					} catch {
+						// Skip malformed JSON
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+
+		yield { type: "done" };
+	}
+}

--- a/apps/web-client/src/services/ai/gemini-provider.ts
+++ b/apps/web-client/src/services/ai/gemini-provider.ts
@@ -1,0 +1,111 @@
+/**
+ * Google Gemini Provider
+ * Uses streamGenerateContent API with API key as URL parameter (no CORS issues).
+ * Free tier: 15 RPM with gemini-2.0-flash.
+ */
+
+import type {
+	AIMessage,
+	AIModelInfo,
+	AIProvider,
+	AIProviderConfig,
+	AIStreamChunk,
+} from "./types";
+
+export class GeminiProvider implements AIProvider {
+	readonly type = "gemini" as const;
+	readonly displayName = "Google Gemini";
+	readonly models: AIModelInfo[] = [
+		{ id: "gemini-2.0-flash", name: "Gemini 2.0 Flash", contextWindow: 1048576, isFree: true },
+	];
+
+	async *streamChat(
+		messages: AIMessage[],
+		config: AIProviderConfig,
+		signal?: AbortSignal,
+	): AsyncGenerator<AIStreamChunk> {
+		// Convert to Gemini format: system instruction + contents
+		const systemMessage = messages.find((m) => m.role === "system");
+		const conversationMessages = messages.filter((m) => m.role !== "system");
+
+		const contents = conversationMessages.map((m) => ({
+			role: m.role === "assistant" ? "model" : "user",
+			parts: [{ text: m.content }],
+		}));
+
+		const body: Record<string, unknown> = {
+			contents,
+			generationConfig: {
+				maxOutputTokens: config.maxTokens ?? 4096,
+			},
+		};
+
+		if (systemMessage) {
+			body.systemInstruction = {
+				parts: [{ text: systemMessage.content }],
+			};
+		}
+
+		const url = `https://generativelanguage.googleapis.com/v1beta/models/${config.model}:streamGenerateContent?alt=sse&key=${config.apiKey}`;
+
+		const response = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+			signal,
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text().catch(() => "Unknown error");
+			let message: string;
+			try {
+				const errorJson = JSON.parse(errorText);
+				message = errorJson.error?.message || errorText;
+			} catch {
+				message = errorText;
+			}
+			yield { type: "error", error: `Gemini API error (${response.status}): ${message}` };
+			return;
+		}
+
+		const reader = response.body?.getReader();
+		if (!reader) {
+			yield { type: "error", error: "No response body" };
+			return;
+		}
+
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() || "";
+
+				for (const line of lines) {
+					const trimmed = line.trim();
+					if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+					const data = trimmed.slice(6);
+					try {
+						const parsed = JSON.parse(data);
+						const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text;
+						if (text) {
+							yield { type: "text", text };
+						}
+					} catch {
+						// Skip malformed JSON
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+
+		yield { type: "done" };
+	}
+}

--- a/apps/web-client/src/services/ai/gemini-provider.ts
+++ b/apps/web-client/src/services/ai/gemini-provider.ts
@@ -16,7 +16,12 @@ export class GeminiProvider implements AIProvider {
 	readonly type = "gemini" as const;
 	readonly displayName = "Google Gemini";
 	readonly models: AIModelInfo[] = [
-		{ id: "gemini-2.0-flash", name: "Gemini 2.0 Flash", contextWindow: 1048576, isFree: true },
+		{
+			id: "gemini-2.0-flash",
+			name: "Gemini 2.0 Flash",
+			contextWindow: 1048576,
+			isFree: true,
+		},
 	];
 
 	async *streamChat(
@@ -66,7 +71,10 @@ export class GeminiProvider implements AIProvider {
 			} catch {
 				message = errorText;
 			}
-			yield { type: "error", error: `Gemini API error (${response.status}): ${message}` };
+			yield {
+				type: "error",
+				error: `Gemini API error (${response.status}): ${message}`,
+			};
 			return;
 		}
 

--- a/apps/web-client/src/services/ai/gemini-provider.ts
+++ b/apps/web-client/src/services/ai/gemini-provider.ts
@@ -46,6 +46,8 @@ export class GeminiProvider implements AIProvider {
 			};
 		}
 
+		// Note: Gemini requires API key as URL param for browser CORS compatibility.
+		// Header-based auth is not supported for direct browser requests.
 		const url = `https://generativelanguage.googleapis.com/v1beta/models/${config.model}:streamGenerateContent?alt=sse&key=${config.apiKey}`;
 
 		const response = await fetch(url, {

--- a/apps/web-client/src/services/ai/index.ts
+++ b/apps/web-client/src/services/ai/index.ts
@@ -4,6 +4,14 @@
 
 import { CredentialStore } from "@ide/storage";
 
+export {
+	getAllProviderTypes,
+	getCredentialKey,
+	getDefaultModel,
+	getDefaultProvider,
+	getProvider,
+} from "./provider-registry";
+export { buildSystemPrompt } from "./system-prompt";
 export type {
 	AIMessage,
 	AIModelInfo,
@@ -14,16 +22,6 @@ export type {
 	ChatMessage,
 	SQLBlock,
 } from "./types";
-
-export {
-	getAllProviderTypes,
-	getCredentialKey,
-	getDefaultModel,
-	getDefaultProvider,
-	getProvider,
-} from "./provider-registry";
-
-export { buildSystemPrompt } from "./system-prompt";
 
 /**
  * Obfuscated credential store for AI API keys.
@@ -135,9 +133,7 @@ class ObfuscatedCredentialStore {
 		if (typeof raw === "string" && raw.length > 24) {
 			try {
 				const key = await this.getDeviceKey();
-				const combined = Uint8Array.from(atob(raw), (c) =>
-					c.charCodeAt(0),
-				);
+				const combined = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
 				const iv = combined.slice(0, 12);
 				const ciphertext = combined.slice(12);
 				const decrypted = await crypto.subtle.decrypt(

--- a/apps/web-client/src/services/ai/index.ts
+++ b/apps/web-client/src/services/ai/index.ts
@@ -1,0 +1,24 @@
+/**
+ * AI Service - Barrel Exports
+ */
+
+export type {
+	AIMessage,
+	AIModelInfo,
+	AIProvider,
+	AIProviderConfig,
+	AIProviderType,
+	AIStreamChunk,
+	ChatMessage,
+	SQLBlock,
+} from "./types";
+
+export {
+	getAllProviderTypes,
+	getCredentialKey,
+	getDefaultModel,
+	getDefaultProvider,
+	getProvider,
+} from "./provider-registry";
+
+export { buildSystemPrompt } from "./system-prompt";

--- a/apps/web-client/src/services/ai/index.ts
+++ b/apps/web-client/src/services/ai/index.ts
@@ -2,6 +2,8 @@
  * AI Service - Barrel Exports
  */
 
+import { CredentialStore } from "@ide/storage";
+
 export type {
 	AIMessage,
 	AIModelInfo,
@@ -22,3 +24,138 @@ export {
 } from "./provider-registry";
 
 export { buildSystemPrompt } from "./system-prompt";
+
+/**
+ * Obfuscated credential store for AI API keys.
+ * Wraps CredentialStore with AES-GCM encryption using a device-bound key.
+ * Prevents casual reading of plaintext API keys from localStorage,
+ * but note this is NOT protection against a determined attacker with
+ * full access to the browser (the key is stored in IndexedDB).
+ */
+class ObfuscatedCredentialStore {
+	private store = new CredentialStore();
+	private keyPromise: Promise<CryptoKey> | null = null;
+
+	private async getDeviceKey(): Promise<CryptoKey> {
+		if (!this.keyPromise) {
+			this.keyPromise = this.loadOrCreateKey();
+		}
+		return this.keyPromise;
+	}
+
+	private async loadOrCreateKey(): Promise<CryptoKey> {
+		// Try to load existing key from IndexedDB
+		const stored = await this.idbGet("dbxlite-device-key");
+		if (stored) {
+			return crypto.subtle.importKey("raw", stored, "AES-GCM", false, [
+				"encrypt",
+				"decrypt",
+			]);
+		}
+		// Generate a new random key and persist it
+		const key = await crypto.subtle.generateKey(
+			{ name: "AES-GCM", length: 256 },
+			true,
+			["encrypt", "decrypt"],
+		);
+		const exported = await crypto.subtle.exportKey("raw", key);
+		await this.idbSet("dbxlite-device-key", new Uint8Array(exported));
+		return key;
+	}
+
+	private idbGet(key: string): Promise<Uint8Array | null> {
+		return new Promise((resolve) => {
+			try {
+				const req = indexedDB.open("dbxlite-keys", 1);
+				req.onupgradeneeded = () => {
+					req.result.createObjectStore("keys");
+				};
+				req.onsuccess = () => {
+					const tx = req.result.transaction("keys", "readonly");
+					const get = tx.objectStore("keys").get(key);
+					get.onsuccess = () => resolve(get.result || null);
+					get.onerror = () => resolve(null);
+				};
+				req.onerror = () => resolve(null);
+			} catch {
+				resolve(null);
+			}
+		});
+	}
+
+	private idbSet(key: string, value: Uint8Array): Promise<void> {
+		return new Promise((resolve) => {
+			try {
+				const req = indexedDB.open("dbxlite-keys", 1);
+				req.onupgradeneeded = () => {
+					req.result.createObjectStore("keys");
+				};
+				req.onsuccess = () => {
+					const tx = req.result.transaction("keys", "readwrite");
+					tx.objectStore("keys").put(value, key);
+					tx.oncomplete = () => resolve();
+					tx.onerror = () => resolve();
+				};
+				req.onerror = () => resolve();
+			} catch {
+				resolve();
+			}
+		});
+	}
+
+	async save(id: string, payload: unknown): Promise<void> {
+		if (payload == null) {
+			return this.store.save(id, null);
+		}
+		try {
+			const key = await this.getDeviceKey();
+			const iv = crypto.getRandomValues(new Uint8Array(12));
+			const encoded = new TextEncoder().encode(JSON.stringify(payload));
+			const encrypted = await crypto.subtle.encrypt(
+				{ name: "AES-GCM", iv },
+				key,
+				encoded,
+			);
+			// Store as base64: iv + ciphertext
+			const combined = new Uint8Array(iv.length + encrypted.byteLength);
+			combined.set(iv);
+			combined.set(new Uint8Array(encrypted), iv.length);
+			return this.store.save(id, btoa(String.fromCharCode(...combined)));
+		} catch {
+			// Fallback to plain storage if crypto fails
+			return this.store.save(id, payload);
+		}
+	}
+
+	async load(id: string): Promise<unknown> {
+		const raw = await this.store.load(id);
+		if (!raw) return null;
+
+		// If it's a string that looks like base64 (our encrypted format), decrypt
+		if (typeof raw === "string" && raw.length > 24) {
+			try {
+				const key = await this.getDeviceKey();
+				const combined = Uint8Array.from(atob(raw), (c) =>
+					c.charCodeAt(0),
+				);
+				const iv = combined.slice(0, 12);
+				const ciphertext = combined.slice(12);
+				const decrypted = await crypto.subtle.decrypt(
+					{ name: "AES-GCM", iv },
+					key,
+					ciphertext,
+				);
+				return JSON.parse(new TextDecoder().decode(decrypted));
+			} catch {
+				// Could be a legacy plaintext value, return as-is
+				return raw;
+			}
+		}
+
+		// Legacy plaintext value
+		return raw;
+	}
+}
+
+/** Shared credential store singleton for AI API keys (encrypted at rest) */
+export const aiCredentialStore = new ObfuscatedCredentialStore();

--- a/apps/web-client/src/services/ai/openai-compatible-provider.ts
+++ b/apps/web-client/src/services/ai/openai-compatible-provider.ts
@@ -61,7 +61,10 @@ export class OpenAICompatibleProvider implements AIProvider {
 			} catch {
 				message = errorText;
 			}
-			yield { type: "error", error: `${this.displayName} API error (${response.status}): ${message}` };
+			yield {
+				type: "error",
+				error: `${this.displayName} API error (${response.status}): ${message}`,
+			};
 			return;
 		}
 

--- a/apps/web-client/src/services/ai/openai-compatible-provider.ts
+++ b/apps/web-client/src/services/ai/openai-compatible-provider.ts
@@ -1,0 +1,113 @@
+/**
+ * OpenAI-Compatible Provider
+ * Handles OpenAI and Groq APIs (same SSE streaming format, different base URLs).
+ */
+
+import type {
+	AIMessage,
+	AIModelInfo,
+	AIProvider,
+	AIProviderConfig,
+	AIProviderType,
+	AIStreamChunk,
+} from "./types";
+
+interface OpenAICompatibleConfig {
+	type: AIProviderType;
+	displayName: string;
+	baseUrl: string;
+	models: AIModelInfo[];
+}
+
+export class OpenAICompatibleProvider implements AIProvider {
+	readonly type: AIProviderType;
+	readonly displayName: string;
+	readonly models: AIModelInfo[];
+	private readonly baseUrl: string;
+
+	constructor(config: OpenAICompatibleConfig) {
+		this.type = config.type;
+		this.displayName = config.displayName;
+		this.baseUrl = config.baseUrl;
+		this.models = config.models;
+	}
+
+	async *streamChat(
+		messages: AIMessage[],
+		config: AIProviderConfig,
+		signal?: AbortSignal,
+	): AsyncGenerator<AIStreamChunk> {
+		const response = await fetch(`${this.baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${config.apiKey}`,
+			},
+			body: JSON.stringify({
+				model: config.model,
+				messages: messages.map((m) => ({ role: m.role, content: m.content })),
+				stream: true,
+				max_tokens: config.maxTokens ?? 4096,
+			}),
+			signal,
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text().catch(() => "Unknown error");
+			let message: string;
+			try {
+				const errorJson = JSON.parse(errorText);
+				message = errorJson.error?.message || errorText;
+			} catch {
+				message = errorText;
+			}
+			yield { type: "error", error: `${this.displayName} API error (${response.status}): ${message}` };
+			return;
+		}
+
+		const reader = response.body?.getReader();
+		if (!reader) {
+			yield { type: "error", error: "No response body" };
+			return;
+		}
+
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() || "";
+
+				for (const line of lines) {
+					const trimmed = line.trim();
+					if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+					const data = trimmed.slice(6);
+					if (data === "[DONE]") {
+						yield { type: "done" };
+						return;
+					}
+
+					try {
+						const parsed = JSON.parse(data);
+						const content = parsed.choices?.[0]?.delta?.content;
+						if (content) {
+							yield { type: "text", text: content };
+						}
+					} catch {
+						// Skip malformed JSON chunks
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+
+		yield { type: "done" };
+	}
+}

--- a/apps/web-client/src/services/ai/provider-registry.ts
+++ b/apps/web-client/src/services/ai/provider-registry.ts
@@ -1,0 +1,72 @@
+/**
+ * Provider Registry
+ * Factory for creating AI providers and managing model definitions.
+ */
+
+import { AnthropicProvider } from "./anthropic-provider";
+import { GeminiProvider } from "./gemini-provider";
+import { OpenAICompatibleProvider } from "./openai-compatible-provider";
+import type { AIProvider, AIProviderType } from "./types";
+
+const providers: Record<AIProviderType, () => AIProvider> = {
+	openai: () =>
+		new OpenAICompatibleProvider({
+			type: "openai",
+			displayName: "OpenAI",
+			baseUrl: "https://api.openai.com/v1",
+			models: [
+				{ id: "gpt-4o-mini", name: "GPT-4o Mini", contextWindow: 128000 },
+				{ id: "gpt-4o", name: "GPT-4o", contextWindow: 128000 },
+				{ id: "gpt-4.1-mini", name: "GPT-4.1 Mini", contextWindow: 1047576 },
+			],
+		}),
+
+	anthropic: () => new AnthropicProvider(),
+
+	gemini: () => new GeminiProvider(),
+
+	groq: () =>
+		new OpenAICompatibleProvider({
+			type: "groq",
+			displayName: "Groq",
+			baseUrl: "https://api.groq.com/openai/v1",
+			models: [
+				{
+					id: "llama-3.3-70b-versatile",
+					name: "Llama 3.3 70B",
+					contextWindow: 128000,
+					isFree: true,
+				},
+			],
+		}),
+};
+
+// Cache provider instances
+const instanceCache = new Map<AIProviderType, AIProvider>();
+
+export function getProvider(type: AIProviderType): AIProvider {
+	let provider = instanceCache.get(type);
+	if (!provider) {
+		provider = providers[type]();
+		instanceCache.set(type, provider);
+	}
+	return provider;
+}
+
+export function getDefaultProvider(): AIProviderType {
+	return "gemini";
+}
+
+export function getAllProviderTypes(): AIProviderType[] {
+	return ["gemini", "groq", "openai", "anthropic"];
+}
+
+export function getDefaultModel(type: AIProviderType): string {
+	const provider = getProvider(type);
+	return provider.models[0].id;
+}
+
+/** Credential key used with CredentialStore for each provider */
+export function getCredentialKey(type: AIProviderType): string {
+	return `ai-${type}`;
+}

--- a/apps/web-client/src/services/ai/system-prompt.ts
+++ b/apps/web-client/src/services/ai/system-prompt.ts
@@ -1,0 +1,36 @@
+/**
+ * System Prompt Builder
+ * Constructs a DuckDB-aware system prompt with optional editor context.
+ */
+
+const MAX_EDITOR_LINES = 200;
+
+export function buildSystemPrompt(editorContent?: string): string {
+	let prompt = `You are a SQL assistant for DuckDB, embedded in a privacy-first SQL workbench called dbxlite.
+
+Your capabilities:
+- Write, explain, debug, and optimize SQL queries for DuckDB
+- DuckDB supports modern SQL features: CTEs, window functions, QUALIFY, PIVOT/UNPIVOT, LIST/STRUCT/MAP types, lambda functions, and more
+- DuckDB can query Parquet, CSV, and JSON files directly (e.g., SELECT * FROM 'data.parquet')
+- DuckDB has extensions for httpfs (remote files), spatial, ICU (dates), and more
+
+Guidelines:
+- Provide concise, accurate answers
+- Use DuckDB-specific syntax when relevant (not PostgreSQL or MySQL)
+- When writing SQL, always use code blocks with \`\`\`sql
+- Explain your reasoning briefly
+- If asked to fix an error, identify the root cause and provide the corrected query
+- When optimizing, explain what changed and why`;
+
+	if (editorContent) {
+		const lines = editorContent.split("\n");
+		const truncated = lines.length > MAX_EDITOR_LINES;
+		const content = truncated
+			? lines.slice(0, MAX_EDITOR_LINES).join("\n") + "\n-- ... (truncated)"
+			: editorContent;
+
+		prompt += `\n\nThe user's current SQL editor contains:\n\`\`\`sql\n${content}\n\`\`\``;
+	}
+
+	return prompt;
+}

--- a/apps/web-client/src/services/ai/types.ts
+++ b/apps/web-client/src/services/ai/types.ts
@@ -1,0 +1,59 @@
+/**
+ * AI Provider Types
+ * Core interfaces for the multi-provider AI chat system.
+ */
+
+export type AIProviderType = "openai" | "anthropic" | "gemini" | "groq";
+
+export interface AIModelInfo {
+	id: string;
+	name: string;
+	contextWindow: number;
+	/** Whether this model is available on the provider's free tier */
+	isFree?: boolean;
+}
+
+export interface AIProviderConfig {
+	apiKey: string;
+	model: string;
+	/** Max tokens for the response */
+	maxTokens?: number;
+}
+
+export interface AIMessage {
+	role: "user" | "assistant" | "system";
+	content: string;
+}
+
+export interface AIStreamChunk {
+	type: "text" | "error" | "done";
+	text?: string;
+	error?: string;
+}
+
+export interface SQLBlock {
+	sql: string;
+	index: number;
+}
+
+export interface ChatMessage {
+	id: string;
+	role: "user" | "assistant";
+	content: string;
+	timestamp: number;
+	/** Extracted SQL code blocks from assistant messages */
+	sqlBlocks?: SQLBlock[];
+	/** Whether this message is still being streamed */
+	isStreaming?: boolean;
+}
+
+export interface AIProvider {
+	readonly type: AIProviderType;
+	readonly displayName: string;
+	readonly models: AIModelInfo[];
+	streamChat(
+		messages: AIMessage[],
+		config: AIProviderConfig,
+		signal?: AbortSignal,
+	): AsyncGenerator<AIStreamChunk>;
+}

--- a/apps/web-client/src/stores/aiChatStore.ts
+++ b/apps/web-client/src/stores/aiChatStore.ts
@@ -6,11 +6,11 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { CredentialStore } from "@ide/storage";
 import {
 	type AIProviderType,
 	type ChatMessage,
 	type SQLBlock,
+	aiCredentialStore,
 	buildSystemPrompt,
 	getCredentialKey,
 	getDefaultModel,
@@ -19,8 +19,6 @@ import {
 } from "../services/ai";
 
 const MAX_MESSAGES = 100;
-
-const credentialStore = new CredentialStore();
 
 /** Extract SQL code blocks from markdown text */
 function extractSQLBlocks(content: string): SQLBlock[] {
@@ -54,6 +52,7 @@ interface AIChatActions {
 type AIChatStore = AIChatState & AIChatActions;
 
 let abortController: AbortController | null = null;
+let streamGeneration = 0;
 
 export const useAIChatStore = create<AIChatStore>()(
 	persist(
@@ -73,17 +72,31 @@ export const useAIChatStore = create<AIChatStore>()(
 				const state = get();
 				if (state.isStreaming) return;
 
+				// Abort any lingering previous stream
+				if (abortController) {
+					abortController.abort();
+					abortController = null;
+				}
+
+				// Capture generation to detect if another stream starts during our async gaps
+				const currentGeneration = ++streamGeneration;
+
 				const providerType = state.activeProvider;
 				const model = state.selectedModels[providerType];
 
 				// Load API key from credential store
-				const apiKey = (await credentialStore.load(
+				const apiKey = (await aiCredentialStore.load(
 					getCredentialKey(providerType),
 				)) as string | null;
 				if (!apiKey) {
+					// Check generation hasn't changed during async gap
+					if (currentGeneration !== streamGeneration) return;
 					set({ error: "No API key configured. Open Settings > AI to add one." });
 					return;
 				}
+
+				// Re-check after async gap
+				if (currentGeneration !== streamGeneration) return;
 
 				// Add user message
 				const userMessage: ChatMessage = {

--- a/apps/web-client/src/stores/aiChatStore.ts
+++ b/apps/web-client/src/stores/aiChatStore.ts
@@ -8,14 +8,14 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import {
 	type AIProviderType,
-	type ChatMessage,
-	type SQLBlock,
 	aiCredentialStore,
 	buildSystemPrompt,
+	type ChatMessage,
 	getCredentialKey,
 	getDefaultModel,
 	getDefaultProvider,
 	getProvider,
+	type SQLBlock,
 } from "../services/ai";
 
 const MAX_MESSAGES = 100;
@@ -91,7 +91,9 @@ export const useAIChatStore = create<AIChatStore>()(
 				if (!apiKey) {
 					// Check generation hasn't changed during async gap
 					if (currentGeneration !== streamGeneration) return;
-					set({ error: "No API key configured. Open Settings > AI to add one." });
+					set({
+						error: "No API key configured. Open Settings > AI to add one.",
+					});
 					return;
 				}
 
@@ -116,7 +118,9 @@ export const useAIChatStore = create<AIChatStore>()(
 				};
 
 				set((s) => ({
-					messages: [...s.messages, userMessage, assistantMessage].slice(-MAX_MESSAGES),
+					messages: [...s.messages, userMessage, assistantMessage].slice(
+						-MAX_MESSAGES,
+					),
 					isStreaming: true,
 					error: null,
 				}));
@@ -163,7 +167,11 @@ export const useAIChatStore = create<AIChatStore>()(
 								error: chunk.error || "Stream error",
 								messages: s.messages.map((m) =>
 									m.id === assistantMessage.id
-										? { ...m, isStreaming: false, content: fullContent || "Error occurred." }
+										? {
+												...m,
+												isStreaming: false,
+												content: fullContent || "Error occurred.",
+											}
 										: m,
 								),
 							}));
@@ -190,9 +198,7 @@ export const useAIChatStore = create<AIChatStore>()(
 						set((s) => ({
 							isStreaming: false,
 							messages: s.messages.map((m) =>
-								m.id === assistantMessage.id
-									? { ...m, isStreaming: false }
-									: m,
+								m.id === assistantMessage.id ? { ...m, isStreaming: false } : m,
 							),
 						}));
 					} else {
@@ -201,7 +207,11 @@ export const useAIChatStore = create<AIChatStore>()(
 							error: (err as Error).message || "Unknown error",
 							messages: s.messages.map((m) =>
 								m.id === assistantMessage.id
-									? { ...m, isStreaming: false, content: m.content || "Error occurred." }
+									? {
+											...m,
+											isStreaming: false,
+											content: m.content || "Error occurred.",
+										}
 									: m,
 							),
 						}));
@@ -242,4 +252,5 @@ export const useAIChatStore = create<AIChatStore>()(
 export const useAIMessages = () => useAIChatStore((s) => s.messages);
 export const useAIStreaming = () => useAIChatStore((s) => s.isStreaming);
 export const useAIError = () => useAIChatStore((s) => s.error);
-export const useAIActiveProvider = () => useAIChatStore((s) => s.activeProvider);
+export const useAIActiveProvider = () =>
+	useAIChatStore((s) => s.activeProvider);

--- a/apps/web-client/src/stores/aiChatStore.ts
+++ b/apps/web-client/src/stores/aiChatStore.ts
@@ -1,0 +1,232 @@
+/**
+ * AI Chat Store (Zustand)
+ * Manages AI chat state with localStorage persistence.
+ * API keys stored separately via CredentialStore.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { CredentialStore } from "@ide/storage";
+import {
+	type AIProviderType,
+	type ChatMessage,
+	type SQLBlock,
+	buildSystemPrompt,
+	getCredentialKey,
+	getDefaultModel,
+	getDefaultProvider,
+	getProvider,
+} from "../services/ai";
+
+const MAX_MESSAGES = 100;
+
+const credentialStore = new CredentialStore();
+
+/** Extract SQL code blocks from markdown text */
+function extractSQLBlocks(content: string): SQLBlock[] {
+	const blocks: SQLBlock[] = [];
+	const regex = /```sql\s*\n([\s\S]*?)```/gi;
+	let match: RegExpExecArray | null;
+	let index = 0;
+	while ((match = regex.exec(content)) !== null) {
+		blocks.push({ sql: match[1].trim(), index: index++ });
+	}
+	return blocks;
+}
+
+interface AIChatState {
+	activeProvider: AIProviderType;
+	selectedModels: Record<AIProviderType, string>;
+	messages: ChatMessage[];
+	isStreaming: boolean;
+	error: string | null;
+}
+
+interface AIChatActions {
+	sendMessage: (content: string, editorContent?: string) => Promise<void>;
+	stopStreaming: () => void;
+	clearMessages: () => void;
+	setActiveProvider: (provider: AIProviderType) => void;
+	setSelectedModel: (provider: AIProviderType, model: string) => void;
+	setError: (error: string | null) => void;
+}
+
+type AIChatStore = AIChatState & AIChatActions;
+
+let abortController: AbortController | null = null;
+
+export const useAIChatStore = create<AIChatStore>()(
+	persist(
+		(set, get) => ({
+			activeProvider: getDefaultProvider(),
+			selectedModels: {
+				openai: getDefaultModel("openai"),
+				anthropic: getDefaultModel("anthropic"),
+				gemini: getDefaultModel("gemini"),
+				groq: getDefaultModel("groq"),
+			},
+			messages: [],
+			isStreaming: false,
+			error: null,
+
+			sendMessage: async (content: string, editorContent?: string) => {
+				const state = get();
+				if (state.isStreaming) return;
+
+				const providerType = state.activeProvider;
+				const model = state.selectedModels[providerType];
+
+				// Load API key from credential store
+				const apiKey = (await credentialStore.load(
+					getCredentialKey(providerType),
+				)) as string | null;
+				if (!apiKey) {
+					set({ error: "No API key configured. Open Settings > AI to add one." });
+					return;
+				}
+
+				// Add user message
+				const userMessage: ChatMessage = {
+					id: crypto.randomUUID(),
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+
+				// Add placeholder assistant message for streaming
+				const assistantMessage: ChatMessage = {
+					id: crypto.randomUUID(),
+					role: "assistant",
+					content: "",
+					timestamp: Date.now(),
+					isStreaming: true,
+				};
+
+				set((s) => ({
+					messages: [...s.messages, userMessage, assistantMessage].slice(-MAX_MESSAGES),
+					isStreaming: true,
+					error: null,
+				}));
+
+				// Build messages array for API
+				const systemPrompt = buildSystemPrompt(editorContent);
+				const apiMessages = [
+					{ role: "system" as const, content: systemPrompt },
+					...get()
+						.messages.filter((m) => !m.isStreaming)
+						.map((m) => ({
+							role: m.role as "user" | "assistant",
+							content: m.content,
+						})),
+				];
+
+				const provider = getProvider(providerType);
+				abortController = new AbortController();
+
+				try {
+					let fullContent = "";
+					for await (const chunk of provider.streamChat(
+						apiMessages,
+						{ apiKey, model },
+						abortController.signal,
+					)) {
+						if (chunk.type === "text" && chunk.text) {
+							fullContent += chunk.text;
+							// Update the streaming message in place
+							set((s) => ({
+								messages: s.messages.map((m) =>
+									m.id === assistantMessage.id
+										? {
+												...m,
+												content: fullContent,
+												sqlBlocks: extractSQLBlocks(fullContent),
+											}
+										: m,
+								),
+							}));
+						} else if (chunk.type === "error") {
+							set((s) => ({
+								isStreaming: false,
+								error: chunk.error || "Stream error",
+								messages: s.messages.map((m) =>
+									m.id === assistantMessage.id
+										? { ...m, isStreaming: false, content: fullContent || "Error occurred." }
+										: m,
+								),
+							}));
+							return;
+						}
+					}
+
+					// Finalize the message
+					set((s) => ({
+						isStreaming: false,
+						messages: s.messages.map((m) =>
+							m.id === assistantMessage.id
+								? {
+										...m,
+										isStreaming: false,
+										sqlBlocks: extractSQLBlocks(fullContent),
+									}
+								: m,
+						),
+					}));
+				} catch (err) {
+					if ((err as Error).name === "AbortError") {
+						// User stopped streaming
+						set((s) => ({
+							isStreaming: false,
+							messages: s.messages.map((m) =>
+								m.id === assistantMessage.id
+									? { ...m, isStreaming: false }
+									: m,
+							),
+						}));
+					} else {
+						set((s) => ({
+							isStreaming: false,
+							error: (err as Error).message || "Unknown error",
+							messages: s.messages.map((m) =>
+								m.id === assistantMessage.id
+									? { ...m, isStreaming: false, content: m.content || "Error occurred." }
+									: m,
+							),
+						}));
+					}
+				} finally {
+					abortController = null;
+				}
+			},
+
+			stopStreaming: () => {
+				abortController?.abort();
+				abortController = null;
+			},
+
+			clearMessages: () => set({ messages: [], error: null }),
+
+			setActiveProvider: (provider) => set({ activeProvider: provider }),
+
+			setSelectedModel: (provider, model) =>
+				set((s) => ({
+					selectedModels: { ...s.selectedModels, [provider]: model },
+				})),
+
+			setError: (error) => set({ error }),
+		}),
+		{
+			name: "dbxlite-ai-chat",
+			partialize: (state) => ({
+				activeProvider: state.activeProvider,
+				selectedModels: state.selectedModels,
+				messages: state.messages.filter((m) => !m.isStreaming),
+			}),
+		},
+	),
+);
+
+// Selector hooks
+export const useAIMessages = () => useAIChatStore((s) => s.messages);
+export const useAIStreaming = () => useAIChatStore((s) => s.isStreaming);
+export const useAIError = () => useAIChatStore((s) => s.error);
+export const useAIActiveProvider = () => useAIChatStore((s) => s.activeProvider);


### PR DESCRIPTION
## Summary

- Add built-in AI chat assistant for writing, explaining, fixing, and optimizing SQL
- Support 4 providers: Google Gemini (free), Groq (free), OpenAI, Anthropic
- Streaming responses via native fetch/SSE with zero npm dependencies
- API keys encrypted at rest with AES-GCM using device-bound IndexedDB key
- Right-side drawer panel with SQL code block extraction, Insert/Copy actions
- Settings tab for provider selection, API key management, and model configuration
- Keyboard shortcut `Cmd/Ctrl+Shift+A` to toggle

## New files (11)
- `services/ai/` -- Provider abstraction layer (types, 4 providers, registry, system prompt)
- `stores/aiChatStore.ts` -- Zustand store with persist middleware
- `components/AIChatPanel.tsx` -- Chat drawer UI
- `components/AIChatMessage.tsx` -- Message renderer with markdown-lite
- `components/settings/AISettings.tsx` -- Settings tab

## Modified files (9)
- `App.tsx` -- Wire AI panel visibility + mutual exclusivity
- `Header.tsx` -- Sparkles toggle button
- `Icons.tsx` -- SparklesIcon, SendIcon
- `EditorPane.tsx` -- insertAtCursor for "Insert" action
- `SettingsModal.tsx` -- AI settings tab
- `DialogsContainer.tsx` -- AIChatPanel rendering
- `useKeyboardShortcuts.ts` -- Cmd+Shift+A shortcut
- `useUIVisibility.ts` -- showAIChat state
- `README.md` -- Feature documentation

## Test plan
- [x] Lint passes (biome, 229 files, 0 errors)
- [x] Build passes (vite, 14.56s)
- [x] Tests pass (753/753, vitest)
- [x] Manual testing: panel open/close, provider switching, streaming, Insert/Copy
- [x] Critic code review: 2 rounds, all issues resolved

Closes #3