### PR TITLE
fix(groq): replace deprecated models

### DIFF
--- a/apps/web-client/src/components/ai/ApiKeyInlineField.tsx
+++ b/apps/web-client/src/components/ai/ApiKeyInlineField.tsx
@@ -114,7 +114,7 @@ export default function ApiKeyInlineField({
 
 				for await (const chunk of p.streamChat(
 					[{ role: "user", content: "Reply with the single word OK." }],
-					{ apiKey: key, model, maxTokens: 5 },
+					{ apiKey: key, model, maxTokens: 256 },
 					controller.signal,
 				)) {
 					if (chunk.type === "error") {

--- a/apps/web-client/src/services/ai/provider-registry.ts
+++ b/apps/web-client/src/services/ai/provider-registry.ts
@@ -32,14 +32,14 @@ const providers: Record<AIProviderType, () => AIProvider> = {
 			baseUrl: "https://api.groq.com/openai/v1",
 			models: [
 				{
-					id: "llama-3.3-70b-versatile",
-					name: "Llama 3.3 70B",
+					id: "openai/gpt-oss-120b",
+					name: "GPT-OSS 120B",
 					contextWindow: 131072,
 					isFree: true,
 				},
 				{
-					id: "llama-3.1-8b-instant",
-					name: "Llama 3.1 8B (Instant)",
+					id: "openai/gpt-oss-20b",
+					name: "GPT-OSS 20B",
 					contextWindow: 131072,
 					isFree: true,
 				},


### PR DESCRIPTION
## Summary

- Replace deprecated Groq Llama models with `openai/gpt-oss-120b` and `openai/gpt-oss-20b`
- Increase the Groq API-key validation request from 5 to 256 max tokens
- Fix Groq GPT-OSS streaming validation, which can emit reasoning chunks before content

## Validation

- `pnpm install` — passed
- Tests — 1671 passed, 10 skipped
- Build — passed
- `git diff --check` — passed
- Manual Groq API tests — passed

Fixes #11